### PR TITLE
fix: Add ProGuard rules to prevent crashes in release builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ example/example/assets/models/gemma-3-270m_vocab.json
 example/assets/models/gemma-3-270m_xnnpack.pte
 example/assets/models/gemma-3-270m_tokenizer_config.json
 example/assets/models/gemma-3-270m_vocab.json
+example/android/.kotlin/sessions/kotlin-compiler-17735043791835568195.salive

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [next]
+
+### Bug Fixes
+- **Android**: Added ProGuard rules to prevent crashes in release builds when loading models
+
 ## 0.0.4
 
 ### Improvements

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,6 +44,7 @@ android {
 
     defaultConfig {
         minSdkVersion 23  // Required for ExecuTorch
+        consumerProguardFiles 'proguard-rules.pro'
     }
 
     dependencies {

--- a/android/proguard-rules.pro
+++ b/android/proguard-rules.pro
@@ -1,0 +1,17 @@
+# ExecuTorch Flutter Plugin ProGuard Rules
+# These rules prevent ProGuard from removing or obfuscating classes needed at runtime
+
+# Keep all ExecuTorch classes
+# ExecuTorch uses reflection and JNI to access these classes
+-keep class org.pytorch.executorch.** { *; }
+-dontwarn org.pytorch.executorch.**
+
+# Keep fbjni (Facebook JNI) classes
+# Required for Java-to-native bridging
+-keep class com.facebook.jni.** { *; }
+-dontwarn com.facebook.jni.**
+
+# Keep SoLoader classes
+# Required for loading native libraries
+-keep class com.facebook.soloader.** { *; }
+-dontwarn com.facebook.soloader.**

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -143,7 +143,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.3"
+    version: "0.0.4"
   fake_async:
     dependency: transitive
     description:


### PR DESCRIPTION
Thanks to https://github.com/abdelaziz-mahdy/executorch_flutter/issues/10

## Summary

Adds ProGuard rules to fix crashes in Android release builds when loading ExecuTorch models.

## Problem

Android apps using this plugin crash in release builds when attempting to load models. The app launches successfully but crashes with `NoSuchMethodError` during model loading:

```
java.lang.NoSuchMethodError: no static or non-static method
"Lorg/pytorch/executorch/Module;.executeNative(...)"
```

**Root Cause**: ProGuard obfuscates ExecuTorch classes (specifically `SoLoader` → `f0.a`), breaking JNI method lookup at runtime.

## Solution

Added ProGuard rules that are automatically applied to consumer apps:

**File**: `android/proguard-rules.pro`
```proguard
# Keep all ExecuTorch classes
-keep class org.pytorch.executorch.** { *; }
-dontwarn org.pytorch.executorch.**

# Keep fbjni (Facebook JNI) classes
-keep class com.facebook.jni.** { *; }
-dontwarn com.facebook.jni.**

# Keep SoLoader classes
-keep class com.facebook.soloader.** { *; }
-dontwarn com.facebook.soloader.**
```

**File**: `android/build.gradle`
```gradle
defaultConfig {
    minSdkVersion 23
    consumerProguardFiles 'proguard-rules.pro'  // ← Added
}
```

## Testing

Verified on Pixel 10 Pro (Android 16) with example app:

- ✅ **WITH ProGuard rules**: App launches and loads models successfully
- ❌ **WITHOUT ProGuard rules**: App launches but crashes on model loading

## Changes

- Added `android/proguard-rules.pro` with ExecuTorch class preservation rules
- Updated `android/build.gradle` to reference ProGuard rules via `consumerProguardFiles`
- Updated `CHANGELOG.md` with bug fix entry

## Impact

Users no longer need to manually add ProGuard rules to their apps. The fix is automatically applied when the plugin is added as a dependency.


