### PR TITLE
fix: Exclude only root-level build/ directory in .pubignore

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -10,8 +10,8 @@ example/ios/.gitignore
 example/macos/.gitignore
 ios/.gitignore
 
-# Build artifacts and generated files
-build/
+# Build artifacts and generated files (root level only, not lib/src/build/)
+/build/
 .dart_tool/
 .flutter-plugins
 .flutter-plugins-dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.2
+
+### Fixed
+- Fixed `.pubignore` pattern `build/` excluding `lib/src/build/run_build.dart` from published package
+  - This caused "No such file or directory" errors when using the package from pub.dev
+  - Changed to `/build/` to only match root-level build directory
+
 ## 0.2.1
 
 ### Fixed

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: executorch_flutter
 description: >
   ExecuTorch ML inference for Flutter using dart:ffi.
   Supports Android, iOS, macOS, Linux, Windows, and Web.
-version: 0.2.1
+version: 0.2.2
 homepage: https://github.com/abdelaziz-mahdy/executorch_flutter
 repository: https://github.com/abdelaziz-mahdy/executorch_flutter
 


### PR DESCRIPTION
fixes: https://github.com/abdelaziz-mahdy/executorch_flutter/issues/23

## Summary

- Fixed `.pubignore` pattern `build/` excluding `lib/src/build/run_build.dart` from published package
- Changed to `/build/` to only match root-level build directory
- Bumps version to 0.2.2

## Problem

Users installing `executorch_flutter` from pub.dev (version 0.2.1) were getting:

```
Error when reading '.../lib/src/build/run_build.dart': No such file or directory
```

This was because the `.pubignore` pattern `build/` matched any directory named `build` at any level, incorrectly excluding `lib/src/build/` from the published package.

## Fix

Changed `.pubignore` from:
```
build/
```

To:
```
/build/
```

The leading `/` ensures only the root-level `build/` directory is excluded.

## Test plan

- [x] Verified `dart pub publish --dry-run` now includes `lib/src/build/run_build.dart`
- [ ] Merge and publish 0.2.2 to pub.dev
- [ ] Verify package works from pub.dev