### PR TITLE
feat: Enable MPS backend on iOS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ dart pub publish --dry-run
 - **Minimum Version**: iOS 13.0
 - **Architectures**: arm64 (device), arm64-simulator, x86_64-simulator (all supported)
 - **Dependencies**: ExecuTorch pre-built native libraries via native assets
-- **Backend**: XNNPACK, CoreML, Vulkan (opt-in, via MoltenVK)
+- **Backend**: XNNPACK, CoreML, MPS (Metal Performance Shaders), Vulkan (opt-in, via MoltenVK)
 
 ### macOS
 - **Minimum Version**: macOS 11.0

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ final model = await ExecuTorchModel.load('/path/to/model.pte');
 | Platform | Min Version | Architectures | Backends |
 |----------|-------------|---------------|----------|
 | **Android** | API 23 | arm64-v8a, armeabi-v7a, x86_64, x86 | XNNPACK, Vulkan* |
-| **iOS** | 13.0+ | arm64, x86_64+arm64 (sim) | XNNPACK, CoreML, Vulkan* |
+| **iOS** | 13.0+ | arm64, x86_64+arm64 (sim) | XNNPACK, CoreML, MPS, Vulkan* |
 | **macOS** | 11.0+ | arm64, x86_64 | XNNPACK, CoreML, MPS, Vulkan* |
 | **Windows** | 10+ | x64 | XNNPACK, Vulkan* |
 | **Linux** | Ubuntu 20.04+ | x64, arm64 | XNNPACK, Vulkan* |
@@ -203,7 +203,7 @@ print('Available: ${backends.map((b) => b.displayName).join(", ")}');
 |---------|--------------|-----------|
 | `Backend.xnnpack` | XNNPACK | All |
 | `Backend.coreml` | CoreML | iOS, macOS |
-| `Backend.mps` | Metal Performance Shaders | macOS |
+| `Backend.mps` | Metal Performance Shaders | iOS, macOS |
 | `Backend.vulkan` | Vulkan | Android, iOS, macOS, Windows, Linux |
 
 ### Exception Hierarchy
@@ -258,7 +258,7 @@ hooks:
 | Platform | Defaults |
 |----------|----------|
 | Android | xnnpack |
-| iOS | xnnpack, coreml |
+| iOS | xnnpack, coreml, mps |
 | macOS | xnnpack, coreml, mps |
 | Windows/Linux | xnnpack |
 

--- a/lib/src/build/run_build.dart
+++ b/lib/src/build/run_build.dart
@@ -73,7 +73,7 @@ const String _packageName = 'executorch_flutter';
 /// Default prebuilt release version (our release tag for prebuilt downloads).
 /// This includes a build iteration suffix (e.g., 1.1.0.1) to support multiple
 /// releases for the same ExecuTorch version.
-const String _defaultPrebuiltVersion = '$executorchVersion.8';
+const String _defaultPrebuiltVersion = '$executorchVersion.9';
 
 /// Default build mode.
 const String _defaultBuildMode = 'prebuilt';
@@ -406,7 +406,7 @@ Map<String, String?> _getBackendDefines(BuildInput input, OS targetOS) {
   // Platform support for each backend
   final isApplePlatform = targetOS == OS.iOS || targetOS == OS.macOS;
   final supportsCoreml = isApplePlatform;
-  final supportsMps = targetOS == OS.macOS;
+  final supportsMps = isApplePlatform;
   // Vulkan available on all native platforms (native assets don't run for web)
   // Note: On Apple platforms, Vulkan via MoltenVK may crash - use at own risk
   const supportsVulkan = true;
@@ -419,9 +419,9 @@ Map<String, String?> _getBackendDefines(BuildInput input, OS targetOS) {
   final enableCoreml =
       supportsCoreml && (backends?.contains('coreml') ?? isApplePlatform);
 
-  // MPS only on macOS
+  // MPS on Apple platforms (macOS and iOS 15.4+)
   final enableMps =
-      supportsMps && (backends?.contains('mps') ?? (targetOS == OS.macOS));
+      supportsMps && (backends?.contains('mps') ?? isApplePlatform);
 
   // Vulkan opt-in and only on supported platforms
   final enableVulkan =


### PR DESCRIPTION
## Summary
- Enable MPS (Metal Performance Shaders) backend for iOS (15.4+)
- Update native submodule to v1.1.0.9 with iOS MPS build variants
- Update prebuilt version to 1.1.0.9

Closes #28

## Note
Waiting for native CI to finish building iOS MPS prebuilts before merging.