### PR TITLE
chore: release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
-## 0.5.0-rc.4
+## 0.5.0
+
+First stable release of the 0.5.x line (supersedes 0.5.0-rc.1 … rc.4).
 
 ### Added
 - **All 13 tensor dtypes supported end-to-end** — thanks @kuldeepdhaka
@@ -9,19 +11,6 @@
   `float16`, `bfloat16`, wired through the native layer (prebuilts v1.3.1.9).
   `float16`/`bfloat16` round to nearest even (numpy/PyTorch behavior), and
   unknown dtypes now error instead of silently becoming `float32`.
-
-### Fixed
-- `int8` tensor encoding applied a +128 bias instead of two's complement,
-  corrupting negative values.
-
-### Breaking
-- `TensorType` values reordered to match native `ETDType` — don't rely on
-  `.index`/`.values` order. `ExtendedTensorType` merged into `TensorType`
-  (deprecated typedef kept; its helper methods removed).
-
-## 0.5.0-rc.3
-
-### Added
 - **On-device LLM (experimental) — Gemma 4 E2B.** Streaming, multi-turn text
   generation via ExecuTorch's `extension/llm/runner`, with a new `ExecuTorchLLM`
   API (`load` / `generate` `Stream<String>` / `stop` / `reset` / `dispose`) and
@@ -36,6 +25,15 @@
   > requires shipping `mlx.metallib` and passing it via
   > `ExecuTorchLLM.load(mlxMetallibPath:)`, plus a macOS 14 deployment target.
   > Distributed as the `xnnpack-llm` / `xnnpack-mlx-llm` prebuilt variants.
+
+### Fixed
+- `int8` tensor encoding applied a +128 bias instead of two's complement,
+  corrupting negative values.
+
+### Breaking
+- `TensorType` values reordered to match native `ETDType` — don't rely on
+  `.index`/`.values` order. `ExtendedTensorType` merged into `TensorType`
+  (deprecated typedef kept; its helper methods removed).
 
 ## 0.4.1
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,18 +27,18 @@ dart pub publish --dry-run
 **executorch_flutter** is a Flutter plugin package that provides on-device machine learning inference using PyTorch ExecuTorch. It enables Flutter developers to run optimized ML models on mobile and desktop platforms with a simple, type-safe Dart API.
 
 **Package Name**: `executorch_flutter`
-**Version**: 0.0.3
+**Version**: see `pubspec.yaml` (`version:`) — the source of truth
 **License**: MIT
 **Platforms**: Android, iOS, macOS, Windows, Linux, Web
 **Flutter Version**: 3.38+ (requires native assets hooks)
 
 ## Current Development Status
 
-- **Phase**: Package implementation complete, API simplified and finalized
-- **API**: Minimal surface with only `load()` and `forward()` - asset bundle loading supported
-- **Code Quality**: 0 lint errors in `lib/`, all dart fixes applied
+- **Status**: published on pub.dev; releases are cut by tagging `v<version>` (CI publishes)
+- **API**: vision inference via `ExecuTorchModel` (`load`/`forward`/`dispose`) plus experimental
+  streaming LLM via `ExecuTorchLLM` (see `docs/LLM.md`)
+- **Code Quality**: `flutter analyze lib` and `dart format --set-exit-if-changed lib` must be clean
 - **Build Status**: ✅ Android, ✅ iOS, ✅ macOS, ✅ Windows, ✅ Linux, ✅ Web
-- **Next Step**: Publish to pub.dev
 
 ## Core Architecture
 
@@ -71,13 +71,13 @@ dart pub publish --dry-run
 - **Minimum Version**: iOS 13.0
 - **Architectures**: arm64 (device), arm64-simulator, x86_64-simulator (all supported)
 - **Dependencies**: ExecuTorch pre-built native libraries via native assets
-- **Backend**: XNNPACK, CoreML, MPS (Metal Performance Shaders), Vulkan (opt-in, via MoltenVK)
+- **Backend**: XNNPACK, CoreML, Vulkan (opt-in, via MoltenVK)
 
 ### macOS
 - **Minimum Version**: macOS 11.0
 - **Architectures**: arm64 (Apple Silicon), x86_64 (Intel) - both supported
 - **Dependencies**: ExecuTorch pre-built native libraries via native assets
-- **Backend**: XNNPACK, CoreML, MPS (Metal Performance Shaders), Vulkan (opt-in, via MoltenVK)
+- **Backend**: XNNPACK, CoreML, Metal, MLX (opt-in, LLM GPU path), Vulkan (opt-in, via MoltenVK)
 
 ### Windows
 - **Minimum Version**: Windows 10
@@ -675,21 +675,7 @@ branch, check `gh run list` for `action_required` and approve via
 
 ## Version History
 
-### 0.0.3 (Current)
-- Full cross-platform support: Android, iOS, macOS, Windows, Linux, Web
-- dart:ffi with native assets for native platforms
-- WebAssembly for web platform
-- User-controlled memory management
-- Example app with YOLO and MobileNet demos
-- Reference processors for common model types
-- Asset bundle loading support
-
-**API Design**:
-- Minimal API surface: Just `load()` and `forward()`
-- No singleton manager, no lifecycle manager
-- Models loaded from `Uint8List` bytes (enables asset bundle loading)
-- Direct tensor return (no wrapper objects)
-- User explicitly manages model lifecycle with `dispose()`
+See `CHANGELOG.md` — it is the source of truth and is updated every release.
 
 ## Known Limitations
 
@@ -745,7 +731,6 @@ Key features:
 
 ---
 
-**Package Version**: 0.0.3
 **Flutter Version**: 3.38+
 **API**: Simplified to `load()` + `forward()` + `dispose()` only
 **Architecture**: dart:ffi with native assets hooks

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ExecuTorch Flutter
 
+[![pub package](https://img.shields.io/pub/v/executorch_flutter.svg)](https://pub.dev/packages/executorch_flutter)
+[![build](https://github.com/abdelaziz-mahdy/executorch_flutter/actions/workflows/build.yml/badge.svg)](https://github.com/abdelaziz-mahdy/executorch_flutter/actions/workflows/build.yml)
+[![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 A Flutter plugin for on-device ML inference using PyTorch ExecuTorch, supporting Android, iOS, macOS, Windows, Linux, and Web.
 
 **[pub.dev](https://pub.dev/packages/executorch_flutter)** | **[Live Demo](https://abdelaziz-mahdy.github.io/executorch_flutter/)** | **[Example App](example/)**
@@ -38,7 +42,8 @@ ExecuTorch Flutter provides a simple Dart API for loading and running ExecuTorch
 - **Async Operations**: Non-blocking model loading and inference
 - **Multiple Models**: Support for concurrent model instances
 - **Error Handling**: Structured exception handling with clear error messages
-- **Backend Support**: XNNPACK, CoreML, MPS, Vulkan backends
+- **Backend Support**: XNNPACK (all platforms), CoreML (Apple), Metal + MLX (macOS), Vulkan (opt-in)
+- **13 Tensor Dtypes**: float32/64, float16, bfloat16, int8/16/32/64, uint8/16/32/64, bool
 - **On-device LLM (experimental)**: streaming text generation with Gemma 4 (XNNPACK CPU + MLX Apple-GPU) — see **[docs/LLM.md](docs/LLM.md)**
 - **Live Camera**: Real-time inference with camera stream support
 
@@ -120,13 +125,13 @@ final model = await ExecuTorchModel.load('/path/to/model.pte');
 | Platform | Min Version | Architectures | Backends |
 |----------|-------------|---------------|----------|
 | **Android** | API 23 | arm64-v8a, armeabi-v7a, x86_64, x86 | XNNPACK, Vulkan* |
-| **iOS** | 13.0+ | arm64, x86_64+arm64 (sim) | XNNPACK, CoreML, MPS, Vulkan* |
-| **macOS** | 11.0+ | arm64, x86_64 | XNNPACK, CoreML, MPS, Vulkan* |
+| **iOS** | 13.0+ | arm64, x86_64+arm64 (sim) | XNNPACK, CoreML, Vulkan* |
+| **macOS** | 11.0+ | arm64, x86_64 | XNNPACK, CoreML, Metal, MLX*, Vulkan* |
 | **Windows** | 10+ | x64 | XNNPACK, Vulkan* |
 | **Linux** | Ubuntu 20.04+ | x64, arm64 | XNNPACK, Vulkan* |
 | **Web** | Modern browsers | WebAssembly | XNNPACK (Wasm SIMD) |
 
-*\*Vulkan is opt-in and experimental. See [Vulkan Backend](#experimental-vulkan-backend).*
+*\*Opt-in. Vulkan is experimental — see [Vulkan Backend](#experimental-vulkan-backend). MLX is the Apple-Silicon GPU runtime used by the LLM path (macOS 14+, arm64) — see [docs/LLM.md](docs/LLM.md).*
 
 ### Platform Configuration
 
@@ -232,9 +237,31 @@ backends: [xnnpack, mlx]   # mlx is auto-dropped off macOS-arm64
 ```dart
 final tensor = TensorData(
   shape: [1, 3, 224, 224],       // Dimensions
-  dataType: TensorType.float32,  // float32, int32, int8, uint8
-  data: Uint8List(...),          // Raw bytes
+  dataType: TensorType.float32,  // See dtype table below
+  data: Uint8List(...),          // Raw bytes, little-endian
   name: 'input_0',               // Optional
+);
+```
+
+**Supported dtypes** — all 13 map 1:1 to ExecuTorch's native types:
+
+| Dtype | Bytes | Dtype | Bytes | Dtype | Bytes |
+|-------|-------|-------|-------|-------|-------|
+| `float32` | 4 | `int8` | 1 | `uint32` | 4 |
+| `float64` | 8 | `int16` | 2 | `uint64` | 8 |
+| `float16` | 2 | `int32` | 4 | `bool_` | 1 |
+| `bfloat16` | 2 | `int64` | 8 | | |
+| `uint8` | 1 | `uint16` | 2 | | |
+
+Building `data` by hand is error-prone, so use `ExecutorchManager` to encode
+numeric lists — it handles float16/bfloat16 conversion (round-to-nearest-even)
+and endianness:
+
+```dart
+final tensor = ExecutorchManager.instance.createTensorData(
+  shape: [1, 4],
+  dataType: TensorType.float16,
+  data: [1.0, 2.5, -3.25, 0.5],
 );
 ```
 
@@ -259,8 +286,10 @@ print('Available: ${backends.map((b) => b.displayName).join(", ")}');
 |---------|--------------|-----------|
 | `Backend.xnnpack` | XNNPACK | All |
 | `Backend.coreml` | CoreML | iOS, macOS |
-| `Backend.mps` | Metal Performance Shaders | iOS, macOS |
+| `Backend.metal` | Metal | macOS |
 | `Backend.vulkan` | Vulkan | Android, iOS, macOS, Windows, Linux |
+| `Backend.qnn` | Qualcomm QNN | Android |
+| `Backend.mps` | *(deprecated — use `metal`)* | macOS |
 
 ### Exception Hierarchy
 
@@ -286,7 +315,7 @@ hooks:
     executorch_flutter:
       debug: false              # Enable debug logging
       build_mode: "prebuilt"    # "prebuilt", "local", or "source"
-      # prebuilt_version: "1.1.0.7"  # Optional: pin specific native version
+      # prebuilt_version: "1.3.1.9"  # Optional: pin specific native version
       # For source mode: build from local ExecuTorch checkout
       # build_mode: "source"
       # executorch_source: "/path/to/executorch"
@@ -295,7 +324,7 @@ hooks:
       backends:
         - xnnpack
         - coreml
-        - mps
+        - metal
 ```
 
 ### Options
@@ -314,9 +343,13 @@ hooks:
 | Platform | Defaults |
 |----------|----------|
 | Android | xnnpack |
-| iOS | xnnpack, coreml, mps |
-| macOS | xnnpack, coreml, mps |
+| iOS | xnnpack, coreml |
+| macOS | xnnpack, coreml, metal |
 | Windows/Linux | xnnpack |
+
+Listing `backends:` replaces the defaults entirely — include every backend you
+want. `vulkan`, `mlx`, and `qnn` are never on by default. A legacy `mps` entry
+is accepted and treated as `metal` on macOS.
 
 ### Environment Variables
 
@@ -442,8 +475,20 @@ See **[docs/LLM.md](docs/LLM.md)** for the full export recipe, the required
 <summary><b>Inference returns error</b></summary>
 
 - Check `model.inputShapes` / `model.outputShapes`
-- Verify tensor data types match expectations
 - Ensure shapes match exactly (including batch dimension)
+- Verify the dtype matches what the model was exported with — a `data size
+  mismatch` error means `data.length` != `elementCount * dataType.sizeInBytes`
+- Prefer `ExecutorchManager.instance.createTensorData(...)` over packing bytes
+  by hand, especially for `float16`/`bfloat16`
+</details>
+
+<details>
+<summary><b>Edits to native C++ code have no effect</b></summary>
+
+The default `prebuilt` build mode downloads an already-compiled library, so
+local changes under `native/` are ignored. Use `build_mode: "source"` with
+`executorch_source:` pointing at a local ExecuTorch checkout. See
+[CONTRIBUTING.md](CONTRIBUTING.md#source-build-from-local-executorch-checkout).
 </details>
 
 <details>
@@ -495,7 +540,7 @@ Some PowerVR devices may produce incorrect Vulkan results due to texture dimensi
 ### Recommendations
 
 - **Production**: Use XNNPACK (stable everywhere)
-- **Apple platforms**: Use CoreML or MPS instead of Vulkan
+- **Apple platforms**: Use CoreML (iOS/macOS) or Metal (macOS) instead of Vulkan
 - **Testing**: Report issues with device info and logs
 
 **[Report Vulkan Issues](https://github.com/abdelaziz-mahdy/executorch_flutter/issues)**

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ ExecuTorch Flutter provides a simple Dart API for loading and running ExecuTorch
 <!-- PACKAGE_VERSION_START -->
 ```yaml
 dependencies:
-  executorch_flutter: ^0.5.0-rc.3
+  executorch_flutter: ^0.5.0
 ```
 <!-- PACKAGE_VERSION_END -->
 

--- a/docs/LLM.md
+++ b/docs/LLM.md
@@ -40,9 +40,17 @@ screen (multi-turn, stop, reset, settings, MLX metallib field).
 
 ## 1. Get the model
 
-LLM weights are large and license/distribution differs from the vision models, so
-they are **not bundled** with the package. Export them yourself (recommended) or
-download a pre-exported set if one is published for your platform.
+LLM weights are large (1+ GB) and carry their own license terms, so — unlike the
+vision models — **nothing is pre-hosted**: there is no download URL to point at.
+You export the model yourself, once, with the scripts below.
+
+Sources you'll need:
+
+- **Base model + `tokenizer.json`**: [`google/gemma-4-E2B-it`](https://huggingface.co/google/gemma-4-E2B-it) on Hugging Face (accept the Gemma terms)
+- **Export scripts**: [`executorch_flutter_models/python`](https://github.com/abdelaziz-mahdy/executorch_flutter_models/tree/main/python)
+- **`mlx.metallib`** (MLX only): [`executorch_native` releases](https://github.com/abdelaziz-mahdy/executorch_native/releases)
+
+The example app's LLM screen lists these same links next to the file pickers.
 
 You need **three** files (for MLX) or **two** (for XNNPACK):
 

--- a/example/CLAUDE.md
+++ b/example/CLAUDE.md
@@ -700,7 +700,7 @@ def export_custom_model():
     # 4. Configure export
     config = ExportConfig(
         model_name='custom_model',
-        backends=['xnnpack', 'coreml', 'mps', 'vulkan'],  # Choose backends
+        backends=['xnnpack', 'coreml', 'metal', 'vulkan'],  # Choose backends
         output_dir='../custom',  # Output directory
         quantize=False,
         input_shapes=[[1, 3, 224, 224]],
@@ -822,4 +822,3 @@ For questions about the example app architecture:
 - File issues at the package repository
 
 **Example App Version**: 1.1
-**Package Version**: 0.0.3

--- a/example/lib/models/model_registry.dart
+++ b/example/lib/models/model_registry.dart
@@ -21,7 +21,7 @@ import '../services/model_index_service.dart';
 /// Backend Information:
 /// - XNNPACK: CPU-optimized, works on ALL platforms (Android, iOS, macOS, Web)
 /// - CoreML: Apple Neural Engine optimization (iOS, macOS)
-/// - MPS: Metal Performance Shaders for GPU acceleration (iOS, macOS)
+/// - Metal: Apple GPU backend (macOS; replaces the removed MPS backend)
 /// - Vulkan: Cross-platform GPU (Android, iOS, macOS, Windows, Linux)
 ///
 /// Model Hosting:
@@ -117,7 +117,9 @@ class ModelRegistry {
     return switch (backend.toLowerCase()) {
       'xnnpack' => Backend.xnnpack,
       'coreml' => Backend.coreml,
-      'mps' => Backend.mps,
+      'metal' => Backend.metal,
+      // Legacy index entries still say "mps"; Metal replaced it upstream.
+      'mps' => Backend.metal,
       'vulkan' => Backend.vulkan,
       'qnn' => Backend.qnn,
       _ => null,

--- a/example/lib/screens/home_screen.dart
+++ b/example/lib/screens/home_screen.dart
@@ -58,25 +58,46 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('ExecuTorch Examples'),
-        elevation: 0,
-      ),
+      appBar: AppBar(title: const Text('ExecuTorch Examples'), elevation: 0),
+      // Cards size to their content and stay centred in a readable column
+      // rather than stretching to fill a desktop-sized window. The min-height
+      // constraint keeps them vertically centred while still allowing scroll
+      // on short viewports.
       body: SafeArea(
         child: LayoutBuilder(
-          builder: (context, constraints) {
-            // One column on narrow screens, two when there's room.
-            final crossAxisCount = constraints.maxWidth >= 720 ? 2 : 1;
-            return GridView.count(
-              crossAxisCount: crossAxisCount,
-              padding: const EdgeInsets.all(16),
-              mainAxisSpacing: 16,
-              crossAxisSpacing: 16,
-              childAspectRatio: crossAxisCount == 1 ? 2.4 : 1.6,
-              children: [
-                for (final category in _categories)
-                  _CategoryCard(category: category),
-              ],
+          builder: (context, viewport) {
+            return SingleChildScrollView(
+              padding: const EdgeInsets.all(24),
+              child: ConstrainedBox(
+                constraints: BoxConstraints(minHeight: viewport.maxHeight - 48),
+                child: Center(
+                  child: ConstrainedBox(
+                    constraints: const BoxConstraints(maxWidth: 840),
+                    child: LayoutBuilder(
+                      builder: (context, constraints) {
+                        const gap = 20.0;
+                        // Two across when there's room, stacked when narrow.
+                        final columns = constraints.maxWidth >= 620 ? 2 : 1;
+                        final cardWidth =
+                            (constraints.maxWidth - gap * (columns - 1)) /
+                            columns;
+                        return Wrap(
+                          spacing: gap,
+                          runSpacing: gap,
+                          alignment: WrapAlignment.center,
+                          children: [
+                            for (final category in _categories)
+                              SizedBox(
+                                width: cardWidth,
+                                child: _CategoryCard(category: category),
+                              ),
+                          ],
+                        );
+                      },
+                    ),
+                  ),
+                ),
+              ),
             );
           },
         ),
@@ -96,14 +117,14 @@ class _CategoryCard extends StatelessWidget {
     return Card(
       clipBehavior: Clip.antiAlias,
       child: InkWell(
-        onTap: () => Navigator.of(context).push(
-          MaterialPageRoute<void>(builder: category.builder),
-        ),
+        onTap: () => Navigator.of(
+          context,
+        ).push(MaterialPageRoute<void>(builder: category.builder)),
         child: Padding(
           padding: const EdgeInsets.all(20),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
-            mainAxisAlignment: MainAxisAlignment.center,
+            mainAxisSize: MainAxisSize.min,
             children: [
               Container(
                 padding: const EdgeInsets.all(12),
@@ -116,21 +137,24 @@ class _CategoryCard extends StatelessWidget {
               const SizedBox(height: 16),
               Text(
                 category.title,
-                style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      fontWeight: FontWeight.w600,
-                    ),
+                style: Theme.of(
+                  context,
+                ).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w600),
               ),
               const SizedBox(height: 6),
               Text(
                 category.subtitle,
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                      color: scheme.onSurfaceVariant,
-                    ),
+                  color: scheme.onSurfaceVariant,
+                ),
               ),
-              const Spacer(),
+              const SizedBox(height: 20),
               Align(
                 alignment: Alignment.bottomRight,
-                child: Icon(Icons.arrow_forward, color: scheme.onSurfaceVariant),
+                child: Icon(
+                  Icons.arrow_forward,
+                  color: scheme.onSurfaceVariant,
+                ),
               ),
             ],
           ),

--- a/example/lib/screens/llm_chat_screen.dart
+++ b/example/lib/screens/llm_chat_screen.dart
@@ -11,6 +11,7 @@ import 'dart:async';
 import 'package:executorch_flutter/executorch_flutter.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 /// A single chat turn.
 class _ChatMessage {
@@ -165,9 +166,7 @@ class _LlmChatScreenState extends State<LlmChatScreen> {
     List<String> extensions,
   ) async {
     final file = await openFile(
-      acceptedTypeGroups: [
-        XTypeGroup(label: label, extensions: extensions),
-      ],
+      acceptedTypeGroups: [XTypeGroup(label: label, extensions: extensions)],
     );
     if (file != null) {
       setState(() => controller.text = file.path);
@@ -191,8 +190,10 @@ class _LlmChatScreenState extends State<LlmChatScreen> {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text('Temperature: ${temperature.toStringAsFixed(2)}'
-                  '${temperature == 0 ? '  (greedy)' : ''}'),
+              Text(
+                'Temperature: ${temperature.toStringAsFixed(2)}'
+                '${temperature == 0 ? '  (greedy)' : ''}',
+              ),
               Slider(
                 value: temperature,
                 max: 1.5,
@@ -310,6 +311,8 @@ class _LlmChatScreenState extends State<LlmChatScreen> {
       title: Text(_loaded ? 'Model loaded' : 'Load a model'),
       childrenPadding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
       children: [
+        const _SetupHelp(),
+        const SizedBox(height: 12),
         TextField(
           controller: _modelPathCtrl,
           decoration: InputDecoration(
@@ -402,7 +405,9 @@ class _LlmChatScreenState extends State<LlmChatScreen> {
   Widget _bubble(BuildContext context, _ChatMessage m) {
     final scheme = Theme.of(context).colorScheme;
     final align = m.fromUser ? Alignment.centerRight : Alignment.centerLeft;
-    final color = m.fromUser ? scheme.primaryContainer : scheme.surfaceContainerHighest;
+    final color = m.fromUser
+        ? scheme.primaryContainer
+        : scheme.surfaceContainerHighest;
     final text = m.text.isEmpty && !m.fromUser ? '…' : m.text;
     return Align(
       alignment: align,
@@ -456,6 +461,114 @@ class _LlmChatScreenState extends State<LlmChatScreen> {
                   ),
           ],
         ),
+      ),
+    );
+  }
+}
+
+/// Explains where the (unbundled) LLM files come from.
+///
+/// Weights are >1 GB and carry their own license terms, so the package ships
+/// neither the model nor the tokenizer. This panel points at the upstream
+/// sources instead. Links are copyable rather than tappable to avoid pulling
+/// url_launcher into the example just for this.
+class _SetupHelp extends StatelessWidget {
+  const _SetupHelp();
+
+  static const _docsUrl =
+      'https://github.com/abdelaziz-mahdy/executorch_flutter/blob/main/docs/LLM.md';
+  static const _exportUrl =
+      'https://github.com/abdelaziz-mahdy/executorch_flutter_models/tree/main/python';
+  static const _tokenizerUrl = 'https://huggingface.co/google/gemma-4-E2B-it';
+  static const _metallibUrl =
+      'https://github.com/abdelaziz-mahdy/executorch_native/releases';
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: scheme.surfaceContainerHighest,
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.info_outline, size: 18, color: scheme.primary),
+              const SizedBox(width: 8),
+              Text(
+                "Don't have the files?",
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 6),
+          Text(
+            'Gemma 4 weights are over 1 GB and carry their own license, so they '
+            'are not bundled. Export them once with the scripts below, then '
+            'point this screen at the resulting files.',
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: scheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 10),
+          const _LinkRow(label: 'Setup guide', url: _docsUrl),
+          const _LinkRow(label: 'Export scripts', url: _exportUrl),
+          const _LinkRow(label: 'Tokenizer (HF)', url: _tokenizerUrl),
+          const _LinkRow(label: 'mlx.metallib (MLX only)', url: _metallibUrl),
+        ],
+      ),
+    );
+  }
+}
+
+/// A labelled URL with a copy button.
+class _LinkRow extends StatelessWidget {
+  const _LinkRow({required this.label, required this.url});
+
+  final String label;
+  final String url;
+
+  @override
+  Widget build(BuildContext context) {
+    final scheme = Theme.of(context).colorScheme;
+    return Padding(
+      padding: const EdgeInsets.only(top: 4),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SizedBox(
+            width: 150,
+            child: Text(label, style: Theme.of(context).textTheme.bodySmall),
+          ),
+          Expanded(
+            child: SelectableText(
+              url,
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(color: scheme.primary),
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.copy, size: 16),
+            tooltip: 'Copy link',
+            visualDensity: VisualDensity.compact,
+            onPressed: () async {
+              await Clipboard.setData(ClipboardData(text: url));
+              if (context.mounted) {
+                ScaffoldMessenger.of(
+                  context,
+                ).showSnackBar(SnackBar(content: Text('Copied $label link')));
+              }
+            },
+          ),
+        ],
       ),
     );
   }

--- a/example/lib/ui/camera_view.dart
+++ b/example/lib/ui/camera_view.dart
@@ -349,7 +349,7 @@ class _CameraViewState extends State<CameraView> with WidgetsBindingObserver {
   }
 
   /// Callback to receive each frame [CameraImage] perform inference on it
-  onLatestImageAvailable(CameraImage cameraImage) async {
+  Future<void> onLatestImageAvailable(CameraImage cameraImage) async {
     // Make sure we are still mounted
     if (!mounted) {
       return;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: executorch_flutter
 description: >
   ExecuTorch on-device ML inference for Flutter using dart:ffi — vision models
   plus experimental streaming LLM (Gemma 4). Android, iOS, macOS, Linux, Windows, Web.
-version: 0.5.0-rc.4
+version: 0.5.0
 homepage: https://github.com/abdelaziz-mahdy/executorch_flutter
 repository: https://github.com/abdelaziz-mahdy/executorch_flutter
 


### PR DESCRIPTION
Promotes the 0.5.x line out of pre-release.

pub.dev treats `0.5.0-rc.N` as a semver prerelease, so `0.4.1` remained the resolved "latest" for `flutter pub add`. This cuts a stable `0.5.0`.

- `pubspec.yaml`: 0.5.0-rc.4 → 0.5.0
- CHANGELOG: rc.3 + rc.4 entries folded into one `## 0.5.0` section
- README dependency snippet updated

No code changes — same tree that shipped in rc.4 (native prebuilts v1.3.1.9).