### PR TITLE
chore: release 0.6.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,7 +173,7 @@ jobs:
   publish:
     name: Publish to pub.dev
     if: startsWith(github.ref, 'refs/tags/v') || github.event.inputs.version != ''
-    needs: [create-release]
+    needs: [get-version, create-release]
     runs-on: ubuntu-latest
     permissions:
       id-token: write  # Required for pub.dev OIDC authentication
@@ -214,8 +214,18 @@ jobs:
       # version that already exists, so check first and skip rather than
       # let that rejection fail the job before the wrapper gets a turn.
       - name: Publish executorch_dart
+        env:
+          TAG_VERSION: ${{ needs.get-version.outputs.version }}
         run: |
           version=$(grep '^version:' packages/executorch_dart/pubspec.yaml | sed 's/^version: *//')
+          # pub.dev's OIDC check requires the tag version to equal the version
+          # being published, so a package whose version does not match this tag
+          # cannot publish from it. Skipping lets the two packages hold
+          # different versions and release under their own tags.
+          if [ "$version" != "$TAG_VERSION" ]; then
+            echo "executorch_dart is $version, tag is $TAG_VERSION — not this package's release, skipping."
+            exit 0
+          fi
           http_status=$(curl -sS --max-time 15 -o /dev/null -w '%{http_code}' \
             "https://pub.dev/api/packages/executorch_dart/versions/$version" || echo "000")
           if [ "$http_status" = "200" ]; then
@@ -225,8 +235,18 @@ jobs:
           fi
 
       - name: Publish executorch_flutter
+        env:
+          TAG_VERSION: ${{ needs.get-version.outputs.version }}
         run: |
           version=$(grep '^version:' packages/executorch_flutter/pubspec.yaml | sed 's/^version: *//')
+          # pub.dev's OIDC check requires the tag version to equal the version
+          # being published, so a package whose version does not match this tag
+          # cannot publish from it. Skipping lets the two packages hold
+          # different versions and release under their own tags.
+          if [ "$version" != "$TAG_VERSION" ]; then
+            echo "executorch_flutter is $version, tag is $TAG_VERSION — not this package's release, skipping."
+            exit 0
+          fi
           http_status=$(curl -sS --max-time 15 -o /dev/null -w '%{http_code}' \
             "https://pub.dev/api/packages/executorch_flutter/versions/$version" || echo "000")
           if [ "$http_status" = "200" ]; then

--- a/packages/executorch_dart/CHANGELOG.md
+++ b/packages/executorch_dart/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.6.1
+
+### Fixed
+
+- The example shown on pub.dev now leads with how to use the package —
+  loading a model, running it, and disposing it — instead of notes that only
+  apply inside this repository.
+
 ## 0.6.0
 
 ### Added

--- a/packages/executorch_dart/README.md
+++ b/packages/executorch_dart/README.md
@@ -53,7 +53,7 @@ automatically — there's nothing to compile by hand.
      packages/executorch_flutter/README.md) — bump this by hand on release. -->
 ```yaml
 dependencies:
-  executorch_dart: ^0.6.0
+  executorch_dart: ^0.6.1
 ```
 
 ## Quick Start
@@ -274,13 +274,6 @@ See **[executorch_flutter's
 README](https://github.com/abdelaziz-mahdy/executorch_flutter/blob/main/packages/executorch_flutter/README.md#build-configuration)**
 for the environment-variable overrides and troubleshooting — it's the same
 build hook underneath.
-
-> **Working in this monorepo?** Pub workspaces read `hooks: user_defines:`
-> only from the **workspace root** `pubspec.yaml` — the same block in a
-> member package's `pubspec.yaml` is silently ignored, and the build falls
-> back to defaults with no error. This only matters if you're building this
-> repo itself; a consumer application is unaffected, since it's its own root
-> package.
 
 ---
 

--- a/packages/executorch_dart/example/README.md
+++ b/packages/executorch_dart/example/README.md
@@ -8,7 +8,7 @@ Add the dependency:
 
 ```yaml
 dependencies:
-  executorch_dart: ^0.6.0
+  executorch_dart: ^0.6.1
 ```
 
 Load a model, run it, dispose it:

--- a/packages/executorch_dart/example/README.md
+++ b/packages/executorch_dart/example/README.md
@@ -1,19 +1,101 @@
 # executorch_dart example
 
-Runs an ExecuTorch model from a plain Dart program. No Flutter.
+Running an ExecuTorch model from a plain Dart program — no Flutter.
 
-```bash
-dart run bin/infer.dart /path/to/mobilenet_v3_xnnpack.pte
+## Using the package
+
+Add the dependency:
+
+```yaml
+dependencies:
+  executorch_dart: ^0.6.0
 ```
 
-Compile it to a self-contained bundle, native library included:
+Load a model, run it, dispose it:
+
+```dart
+import 'dart:typed_data';
+
+import 'package:executorch_dart/executorch_dart.dart';
+
+Future<void> main() async {
+  // Load a .pte file from disk. Use loadFromBytes() if you already have
+  // the bytes in memory.
+  final model = await ExecuTorchModel.load('mobilenet_v3_small_xnnpack.pte');
+
+  // Build the input tensor. Shape and dtype must match what the model was
+  // exported with — MobileNet takes a 224x224 RGB image as float32.
+  final input = TensorData(
+    shape: [1, 3, 224, 224],
+    dataType: TensorType.float32,
+    data: Float32List(1 * 3 * 224 * 224).buffer.asUint8List(),
+    name: 'input',
+  );
+
+  final outputs = await model.forward([input]);
+
+  for (final output in outputs) {
+    print('${output.shape} ${output.dataType}');  // [1, 1000] float32
+  }
+
+  // Free the native model. Nothing is released automatically.
+  await model.dispose();
+}
+```
+
+That is the whole API: `load` / `loadFromBytes`, `forward`, `dispose`.
+
+Errors arrive as `ExecuTorchException` subclasses, so a real program wraps
+the above in a `try` block:
+
+```dart
+try {
+  // ... load, forward, dispose ...
+} on ExecuTorchException catch (e) {
+  stderr.writeln('Error: $e');
+}
+```
+
+Building a Flutter app instead? Use
+[`executorch_flutter`](https://pub.dev/packages/executorch_flutter), which
+wraps this package and adds asset-bundle loading and Web support.
+
+## Running this example
+
+`bin/infer.dart` is the code above with argument handling. Point it at any
+XNNPACK-delegated `.pte`:
+
+```bash
+dart run bin/infer.dart /path/to/mobilenet_v3_small_xnnpack.pte
+```
+
+```
+ExecuTorch 2.0.0
+loaded model_1a2b3c
+outputs: 1
+  shape [1, 1000] dtype TensorType.float32
+ok
+```
+
+The first run compiles the native library, so expect a delay; later runs are
+fast. Compile to a self-contained bundle — native library included — with:
 
 ```bash
 dart build cli
 ./build/cli/*/bundle/bin/infer /path/to/model.pte
 ```
 
-**Copying this example out of the repo?** `pubspec.yaml` pins
-`resolution: workspace`, which only resolves inside this repo's pub
-workspace. Delete that line first — the existing `executorch_dart: ^0.6.0`
-dependency then resolves normally from pub.dev.
+That bundle is what you would deploy to a server.
+
+## Getting a model
+
+`.pte` files are exported from PyTorch. Ready-made ones used by this
+project's tests live in the
+[models repository](https://github.com/abdelaziz-mahdy/executorch_flutter_models/releases).
+Pick an **XNNPACK** build — it is the backend available on every platform.
+
+---
+
+*Copying this example out of the repo? Delete `resolution: workspace` from
+its `pubspec.yaml` first; it only resolves inside this repo's pub workspace.
+The `executorch_dart` dependency then resolves normally from pub.dev.*

--- a/packages/executorch_dart/pubspec.yaml
+++ b/packages/executorch_dart/pubspec.yaml
@@ -2,7 +2,7 @@ name: executorch_dart
 description: >
   ExecuTorch on-device ML inference for pure Dart using dart:ffi — vision
   models plus experimental streaming LLM. Android, iOS, macOS, Linux, Windows.
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/abdelaziz-mahdy/executorch_flutter
 repository: https://github.com/abdelaziz-mahdy/executorch_flutter
 

--- a/packages/executorch_flutter/CHANGELOG.md
+++ b/packages/executorch_flutter/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.6.0
+## 0.6.1
 
 ### Breaking
 

--- a/packages/executorch_flutter/README.md
+++ b/packages/executorch_flutter/README.md
@@ -115,7 +115,7 @@ await model.dispose();
 | `ExecuTorchModel.load(filePath)` | Native only | External file paths |
 
 `loadModelFromAsset` is a top-level function, not a static method on
-`ExecuTorchModel` — this is what changed in 0.6.0 (see
+`ExecuTorchModel` — this is what changed in 0.6.1 (see
 [CHANGELOG.md](CHANGELOG.md)).
 
 ```dart
@@ -346,7 +346,7 @@ hooks:
 The key under `user_defines:` is the package that owns the native build —
 `executorch_dart`, even though you depend on `executorch_flutter`. This
 package used to own the build directly and read `executorch_flutter:` here;
-see the 0.6.0 entry in [CHANGELOG.md](CHANGELOG.md) if you're migrating.
+see the 0.6.1 entry in [CHANGELOG.md](CHANGELOG.md) if you're migrating.
 
 ### Options
 

--- a/packages/executorch_flutter/pubspec.yaml
+++ b/packages/executorch_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: executorch_flutter
 description: >
   ExecuTorch on-device ML inference for Flutter using dart:ffi — vision models
   plus experimental streaming LLM. Android, iOS, macOS, Linux, Windows, Web.
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/abdelaziz-mahdy/executorch_flutter
 repository: https://github.com/abdelaziz-mahdy/executorch_flutter
 
@@ -13,7 +13,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  executorch_dart: ^0.6.0
+  executorch_dart: ^0.6.1
   flutter:
     sdk: flutter
   hooks: ^1.0.0


### PR DESCRIPTION
Release prep for 0.6.1, plus two documentation corrections found while reviewing the freshly-published `executorch_dart` page on pub.dev.

## Why 0.6.1 for both

`executorch_dart` 0.6.0 is published; `executorch_flutter` 0.6.0 never was. Rather than let the two drift, both go to 0.6.1 and release under a single `v0.6.1` tag.

That also means this release exercises the **core's automated publish path**. Under a `v0.6.0` tag the core would have been skipped by the already-published guard, leaving its OIDC configuration unproven until the next release — with no manual fallback rehearsed.

The wrapper's `0.6.0` changelog entry is renamed to `0.6.1` rather than stacked, since no one ever received 0.6.0. The core gets a genuine new entry.

Note that pub.dev emits a hint about the wrapper jumping 0.5.0 → 0.6.1. It is a hint, not a blocker.

## Documentation fixes

- **The core's pub.dev Example tab opened with repo-internal caveats** about `resolution: workspace` instead of showing the API. It now leads with the dependency line and a complete `load` → `forward` → `dispose` snippet, then error handling and a pointer to `executorch_flutter`. Running the CLI comes after; the workspace note is a footnote.
- **Removed the pub-workspace `user_defines` note from the core README.** That is contributor guidance — it only matters when building this repo — and it already lives in `CONTRIBUTING.md`.

## One release-machinery fix

The publish job now skips a package whose version does not match the tag.

pub.dev's OIDC check requires the tag version to equal the version being published. Without this guard, bumping one package and tagging would fail the whole publish job at pub.dev with a version-mismatch error **and** prevent the other package from publishing. It is a no-op while the two versions move together, which is the normal case.

## Verification

`flutter analyze` clean, formatter silent, core 43 tests and wrapper 4 tests passing, both publish dry runs clean apart from the known `docs`→`doc` nit and the version-jump hint.
