### PR TITLE
fix: await async expectations in integration tests

### DIFF
--- a/packages/executorch_flutter/example/integration_test/models_integration_test.dart
+++ b/packages/executorch_flutter/example/integration_test/models_integration_test.dart
@@ -393,9 +393,11 @@ void main() {
     ) async {
       final invalidPath = '/non/existent/model.pte';
 
-      // Attempt to load non-existent model
-      expect(
-        () async => await ExecuTorchModel.load(invalidPath),
+      // Attempt to load non-existent model. expectLater must be awaited:
+      // a bare expect() on an async callback returns before the future
+      // settles, so the assertion would never actually run.
+      await expectLater(
+        () => ExecuTorchModel.load(invalidPath),
         throwsA(isA<ExecuTorchException>()),
         reason: 'Loading non-existent model should throw exception',
       );
@@ -419,8 +421,8 @@ void main() {
         );
 
         // Attempt to run inference on disposed model
-        expect(
-          () async => await model.forward([inputTensor]),
+        await expectLater(
+          () => model.forward([inputTensor]),
           throwsA(isA<ExecuTorchException>()),
           reason: 'Running inference on disposed model should throw exception',
         );
@@ -435,15 +437,23 @@ void main() {
       final invalidFile = File('${directory.path}/invalid_model.pte');
       await invalidFile.writeAsString('This is not a valid model file');
 
-      // Attempt to load invalid model
-      expect(
-        () async => await ExecuTorchModel.load(invalidFile.path),
+      // Attempt to load invalid model. Awaiting matters twice over here:
+      // besides making the assertion real, it lets the failed load release
+      // the file before cleanup runs.
+      await expectLater(
+        () => ExecuTorchModel.load(invalidFile.path),
         throwsA(isA<ExecuTorchException>()),
         reason: 'Loading invalid model file should throw exception',
       );
 
-      // Cleanup
-      await invalidFile.delete();
+      // Cleanup. Windows refuses to delete a file while the native loader
+      // still holds its mmap; POSIX allows it. The file lives in the app
+      // cache directory, so leaving it behind is harmless.
+      try {
+        await invalidFile.delete();
+      } on FileSystemException {
+        // Ignore — see above.
+      }
     });
 
     testWidgets('Should handle multiple dispose calls gracefully', (


### PR DESCRIPTION
Fixes the intermittent Windows failure that has been turning the `release.yml` badge red on `main`.

## The bug

Three error-handling tests passed an async callback to `expect()`:

```dart
expect(
  () async => await ExecuTorchModel.load(invalidFile.path),
  throwsA(isA<ExecuTorchException>()),
);
await invalidFile.delete();
```

`expect()` does not await, so it returns before the future settles. Two consequences:

1. **The assertions never actually ran** — on any platform. All three tests have been passing vacuously.
2. The invalid-model test reached `delete()` while the failed load still held the file's mmap (`MmapUseMlockIgnoreErrors`).

POSIX permits unlinking a mapped file, so macOS and Linux never noticed. Windows does not:

```
Cannot delete file, path = '...\invalid_model.pte'
(OS Error: The process cannot access the file because it is being used by another process, errno = 32)
```

That is a race, not a hard break — the same commit passed on the `v0.6.2` tag run and failed on the `main` run minutes earlier.

## The fix

- All three sites switched to `await expectLater(...)`, so the assertions run for real and the load finishes before cleanup.
- The temp-file delete tolerates `FileSystemException`, in case Windows still holds the mapping. The file lives in the app cache directory, so leaving it is harmless.

## Why it matters beyond the badge

The same flake can fail build checks on a **tag** run and block a release.

## Verification

- `flutter analyze` — no issues
- `dart format` — no changes
- `flutter test integration_test/models_integration_test.dart -d macos` — **All tests passed!** (36 tests)

macOS cannot reproduce the Windows failure, so the Windows half is reasoned rather than locally proven — CI's Build Windows job is the real check.