### PR TITLE
docs: show how to use the tokenizer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -429,5 +429,7 @@ jobs:
         working-directory: ${{ env.STAGE }}/executorch_dart/example
 
       - name: Build CLI example
-        run: dart build cli
+        # bin/ has more than one entry (infer, tokenize), so the target
+        # must be named or `dart build cli` refuses to pick one.
+        run: dart build cli --target bin/infer.dart
         working-directory: ${{ env.STAGE }}/executorch_dart/example

--- a/packages/executorch_dart/README.md
+++ b/packages/executorch_dart/README.md
@@ -332,7 +332,7 @@ dart run bin/infer.dart /path/to/model.pte
 Or compile it to a self-contained bundle with the native library included:
 
 ```bash
-dart build cli
+dart build cli --target bin/infer.dart
 ./build/cli/*/bundle/bin/infer /path/to/model.pte
 ```
 

--- a/packages/executorch_dart/README.md
+++ b/packages/executorch_dart/README.md
@@ -197,6 +197,49 @@ final backends = BackendQuery.available;
 print('Available: ${backends.map((b) => b.displayName).join(", ")}');
 ```
 
+### Tokenizer
+
+Text to token ids and back, with no model attached. This is what encoder
+models need — embeddings, classification, retrieval — because they take token
+ids as an input tensor and produce a vector in a single `forward()`, with no
+generation loop to borrow a tokenizer from.
+
+```dart
+final tokenizer = await Tokenizer.load('/path/to/tokenizer.json');
+
+final ids = tokenizer.encode('some text');
+final input = TensorData(
+  shape: [1, ids.length],
+  dataType: TensorType.int64,
+  data: Int64List.fromList(ids).buffer.asUint8List(),
+);
+final outputs = await model.forward([input]);
+
+print(tokenizer.decode(ids));   // back to text
+tokenizer.dispose();
+```
+
+| Member | Purpose |
+|--------|---------|
+| `Tokenizer.load(path)` | Load a tokenizer file, format auto-detected |
+| `encode(text, {bosCount, eosCount})` | Text to token ids |
+| `decode(ids, {skipSpecialTokens})` | Token ids back to text |
+| `vocabSize` / `bosId` / `eosId` | Vocabulary metadata |
+| `format` | Which reader claimed the file |
+| `dispose()` | Free the native tokenizer |
+
+**Supported formats:** HuggingFace `tokenizer.json` built on **BPE** (GPT-2,
+Llama, Gemma, Qwen, Mistral), SentencePiece `.model`, TikToken, and the
+llama2.c binary format.
+
+**Not supported:** WordPiece / BERT-family tokenizers. The reader derives from
+a BPE base and implements no `BertNormalizer`, which rules out BERT,
+DistilBERT, MiniLM and most sentence-transformers models. Passing one raises
+an error naming the specific reason rather than a generic parse failure.
+
+Not available on Web — this is `dart:ffi` throughout. For generative models
+use `ExecuTorchLLM` below, which owns its tokenizer internally.
+
 ### ExecuTorchLLM (experimental)
 
 On-device generative text — **Google Gemma 4 E2B** — with token-by-token

--- a/packages/executorch_dart/example/README.md
+++ b/packages/executorch_dart/example/README.md
@@ -124,7 +124,7 @@ The first run compiles the native library, so expect a delay; later runs are
 fast. Compile to a self-contained bundle — native library included — with:
 
 ```bash
-dart build cli
+dart build cli --target bin/infer.dart
 ./build/cli/*/bundle/bin/infer /path/to/model.pte
 ```
 

--- a/packages/executorch_dart/example/README.md
+++ b/packages/executorch_dart/example/README.md
@@ -56,6 +56,49 @@ try {
 }
 ```
 
+## Tokenizing text
+
+Encoder models — embeddings, classification, retrieval — take token ids as an
+input tensor rather than pixels. `Tokenizer` handles that half, with no model
+attached:
+
+```dart
+final tokenizer = await Tokenizer.load('tokenizer.json');
+
+final ids = tokenizer.encode('some text');
+final input = TensorData(
+  shape: [1, ids.length],
+  dataType: TensorType.int64,
+  data: Int64List.fromList(ids).buffer.asUint8List(),
+);
+final outputs = await model.forward([input]);
+
+print(tokenizer.decode(ids));
+tokenizer.dispose();
+```
+
+Reads HuggingFace `tokenizer.json` built on BPE, SentencePiece, TikToken and
+llama2.c, detected automatically. WordPiece/BERT-family tokenizers are not
+supported — that covers BERT, DistilBERT, MiniLM and most
+sentence-transformers models — and loading one reports exactly that rather
+than a generic parse error.
+
+Run it against any supported tokenizer file:
+
+```bash
+dart run bin/tokenize.dart /path/to/tokenizer.json "hello world"
+```
+
+```
+format     : hf_json
+vocab size : 50257
+bos / eos  : 50256 / 50256
+
+text   : hello world
+ids    : [31373, 995]
+decoded: hello world
+```
+
 Building a Flutter app instead? Use
 [`executorch_flutter`](https://pub.dev/packages/executorch_flutter), which
 wraps this package and adds asset-bundle loading and Web support.

--- a/packages/executorch_dart/example/bin/tokenize.dart
+++ b/packages/executorch_dart/example/bin/tokenize.dart
@@ -1,0 +1,55 @@
+// ignore_for_file: avoid_print
+
+// Tokenize text with executorch_dart, without loading a model.
+//
+// Encoder models — embeddings, classification, retrieval — take token ids as
+// an input tensor and produce a vector in a single forward() call. They have
+// no generation loop to borrow a tokenizer from, so the tokenizer is exposed
+// on its own.
+//
+//   dart run bin/tokenize.dart /path/to/tokenizer.json "some text"
+
+import 'dart:io';
+
+import 'package:executorch_dart/executorch_dart.dart';
+
+Future<void> main(List<String> args) async {
+  if (args.isEmpty) {
+    stderr.writeln('usage: tokenize <tokenizer.json> [text]');
+    exitCode = 2;
+    return;
+  }
+
+  final text = args.length > 1 ? args[1] : 'hello world';
+
+  Tokenizer? tokenizer;
+  try {
+    tokenizer = await Tokenizer.load(args[0]);
+
+    print('format     : ${tokenizer.format.nativeName}');
+    print('vocab size : ${tokenizer.vocabSize}');
+    print('bos / eos  : ${tokenizer.bosId} / ${tokenizer.eosId}');
+
+    final ids = tokenizer.encode(text);
+    print('');
+    print('text   : $text');
+    print('ids    : $ids');
+    print('decoded: ${tokenizer.decode(ids)}');
+
+    // Feed the ids straight into a model with ExecuTorchModel.forward:
+    //
+    //   final input = TensorData(
+    //     shape: [1, ids.length],
+    //     dataType: TensorType.int64,
+    //     data: Int64List.fromList(ids).buffer.asUint8List(),
+    //   );
+  } on ExecuTorchException catch (e) {
+    // An unsupported tokenizer reports why — a WordPiece model or a
+    // BertNormalizer, for instance — rather than a generic parse failure.
+    stderr.writeln('Error: ${e.message}');
+    exitCode = 1;
+  } finally {
+    // Nothing is released automatically; the lifetime is yours.
+    tokenizer?.dispose();
+  }
+}

--- a/packages/executorch_flutter/README.md
+++ b/packages/executorch_flutter/README.md
@@ -307,6 +307,40 @@ print('Available: ${backends.map((b) => b.displayName).join(", ")}');
 | `Backend.qnn` | Qualcomm QNN | Android |
 | `Backend.mps` | *(deprecated — use `metal`)* | macOS |
 
+### Tokenizer
+
+Text to token ids and back, independent of any model. Encoder models —
+embeddings, classification, retrieval — take token ids as an input tensor and
+produce a vector in a single `forward()`, so they have no generation loop to
+borrow a tokenizer from.
+
+```dart
+final tokenizer = await Tokenizer.load('/path/to/tokenizer.json');
+
+final ids = tokenizer.encode('some text');
+final input = TensorData(
+  shape: [1, ids.length],
+  dataType: TensorType.int64,
+  data: Int64List.fromList(ids).buffer.asUint8List(),
+);
+final outputs = await model.forward([input]);
+
+print(tokenizer.decode(ids));
+tokenizer.dispose();
+```
+
+**Supported:** HuggingFace `tokenizer.json` built on **BPE** (GPT-2, Llama,
+Gemma, Qwen, Mistral), SentencePiece `.model`, TikToken, llama2.c.
+
+**Not supported:** WordPiece / BERT-family — that rules out BERT, DistilBERT,
+MiniLM and most sentence-transformers models. The error names the specific
+reason rather than reporting a generic parse failure.
+
+**Native platforms only.** It is `dart:ffi` throughout with no WebAssembly
+equivalent, so Web code referencing `Tokenizer` fails to compile rather than
+failing at runtime. For generative models use `ExecuTorchLLM`, which owns its
+tokenizer internally.
+
 ### Exception Hierarchy
 
 ```


### PR DESCRIPTION
The `Tokenizer` API shipped with **zero** documentation in `executorch_dart` — the package that owns it. No README section, no example.

## Added

- **`executorch_dart/README.md`** — an API Reference section with usage, a member table, and the supported/unsupported format lists
- **`executorch_flutter/README.md`** — the same, plus the Web caveat: it is `dart:ffi` throughout, so Web code referencing `Tokenizer` fails to compile rather than at runtime
- **`example/bin/tokenize.dart`** — a runnable CLI example next to `infer.dart`
- **`example/README.md`** — a tokenizing section with real sample output

## The output in the docs is real

```
$ dart run bin/tokenize.dart gpt2.json "hello world"
format     : hf_json
vocab size : 50257
bos / eos  : 50256 / 50256

text   : hello world
ids    : [31373, 995]
decoded: hello world
```

Copied from an actual run, not composed. The error path was exercised too — passing a BERT `tokenizer.json` prints the specific diagnosis rather than a generic parse failure.

## Limitations are documented, not buried

WordPiece/BERT-family tokenizers are unsupported, which rules out BERT, DistilBERT, MiniLM and most sentence-transformers models. Someone evaluating this package should learn that from the README rather than from an error after wiring everything up.

`flutter analyze` clean; the `avoid_print` ignore matches the existing `infer.dart`.