### PR TITLE
fix: relink bundled MoltenVK for macOS Vulkan, add Vulkan correctness tests

### DIFF
--- a/packages/executorch_dart/CHANGELOG.md
+++ b/packages/executorch_dart/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.7.1
+
+### Fixed
+
+- macOS Vulkan builds no longer fail with `install_name_tool: ... larger
+  updated load commands do not fit`. The bundled `libMoltenVK.dylib` was
+  copied from Homebrew, which links it without room to grow its install name,
+  so relocating it into an app was impossible. It is now linked from
+  MoltenVK's own static library with that headroom reserved, and the build
+  refuses to package any bundled library lacking it.
+  Thanks @dariyooo ([#51](https://github.com/abdelaziz-mahdy/executorch_flutter/issues/51)).
+  - macOS Vulkan variants now require **macOS 12+**, the floor MoltenVK 1.4.x
+    is compiled against. Other variants keep their macOS 11 target.
+
 ## 0.7.0
 
 ### Added

--- a/packages/executorch_dart/README.md
+++ b/packages/executorch_dart/README.md
@@ -53,7 +53,7 @@ automatically — there's nothing to compile by hand.
      packages/executorch_flutter/README.md) — bump this by hand on release. -->
 ```yaml
 dependencies:
-  executorch_dart: ^0.7.0
+  executorch_dart: ^0.7.1
 ```
 
 ## Quick Start
@@ -279,7 +279,7 @@ hooks:
     executorch_dart:
       debug: false                  # Debug logging + debug binaries
       build_mode: "prebuilt"        # "prebuilt", "local", or "source"
-      # prebuilt_version: "1.4.0.5" # Optional: pin a specific native release
+      # prebuilt_version: "1.4.0.6" # Optional: pin a specific native release
       llm: false                    # Opt in to the LLM runner (ExecuTorchLLM)
       # For source mode: build from local ExecuTorch checkout
       # build_mode: "source"
@@ -302,7 +302,7 @@ hooks:
 | `debug` | `false` | Enable native debug logging and use debug binaries |
 | `local_lib_dir` | - | Path to precompiled `lib/` + `include/` (`build_mode: "local"` only) |
 | `executorch_source` | - | Path to a local ExecuTorch checkout (`build_mode: "source"` only) |
-| `prebuilt_version` | Current release (e.g. `1.4.0.5`) | Pin a specific prebuilt native release instead of this package version's default |
+| `prebuilt_version` | Current release (e.g. `1.4.0.6`) | Pin a specific prebuilt native release instead of this package version's default |
 
 ### Default backends by platform
 

--- a/packages/executorch_dart/example/README.md
+++ b/packages/executorch_dart/example/README.md
@@ -8,7 +8,7 @@ Add the dependency:
 
 ```yaml
 dependencies:
-  executorch_dart: ^0.7.0
+  executorch_dart: ^0.7.1
 ```
 
 Load a model, run it, dispose it:

--- a/packages/executorch_dart/lib/src/build/run_build.dart
+++ b/packages/executorch_dart/lib/src/build/run_build.dart
@@ -73,7 +73,7 @@ const String _packageName = 'executorch_dart';
 /// Default prebuilt release version (our release tag for prebuilt downloads).
 /// This includes a build iteration suffix (e.g., 1.1.0.1) to support multiple
 /// releases for the same ExecuTorch version.
-const String _defaultPrebuiltVersion = '$executorchVersion.5';
+const String _defaultPrebuiltVersion = '$executorchVersion.6';
 
 /// Default build mode.
 const String _defaultBuildMode = 'prebuilt';

--- a/packages/executorch_dart/pubspec.yaml
+++ b/packages/executorch_dart/pubspec.yaml
@@ -2,7 +2,7 @@ name: executorch_dart
 description: >
   ExecuTorch on-device ML inference for pure Dart using dart:ffi — vision
   models plus experimental streaming LLM. Android, iOS, macOS, Linux, Windows.
-version: 0.7.0
+version: 0.7.1
 homepage: https://github.com/abdelaziz-mahdy/executorch_flutter
 repository: https://github.com/abdelaziz-mahdy/executorch_flutter
 

--- a/packages/executorch_flutter/CHANGELOG.md
+++ b/packages/executorch_flutter/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.7.1
+
+### Fixed
+
+- macOS Vulkan builds no longer fail while relocating the bundled MoltenVK
+  library into the app. See the core package's changelog for the cause and the
+  new macOS 12+ requirement for Vulkan variants.
+  Thanks @dariyooo ([#51](https://github.com/abdelaziz-mahdy/executorch_flutter/issues/51)).
+
 ## 0.7.0
 
 ### Added

--- a/packages/executorch_flutter/README.md
+++ b/packages/executorch_flutter/README.md
@@ -55,7 +55,7 @@ and Web support.
 ### Library Size by Backend
 
 <!-- NATIVE_VERSION_START -->
-📊 **[Download Release Size Comparison (SVG)](https://github.com/abdelaziz-mahdy/executorch_native/releases/download/v1.4.0.5/size-report-release.svg)** | **[Download Debug Size Comparison (SVG)](https://github.com/abdelaziz-mahdy/executorch_native/releases/download/v1.4.0.5/size-report-debug.svg)** | **[JSON Report](https://github.com/abdelaziz-mahdy/executorch_native/releases/download/v1.4.0.5/size-report.json)**
+📊 **[Download Release Size Comparison (SVG)](https://github.com/abdelaziz-mahdy/executorch_native/releases/download/v1.4.0.6/size-report-release.svg)** | **[Download Debug Size Comparison (SVG)](https://github.com/abdelaziz-mahdy/executorch_native/releases/download/v1.4.0.6/size-report-debug.svg)** | **[JSON Report](https://github.com/abdelaziz-mahdy/executorch_native/releases/download/v1.4.0.6/size-report.json)**
 <!-- NATIVE_VERSION_END -->
 
 ---
@@ -365,7 +365,7 @@ hooks:
     executorch_dart:
       debug: false              # Enable debug logging
       build_mode: "prebuilt"    # "prebuilt", "local", or "source"
-      # prebuilt_version: "1.4.0.5"  # Optional: pin specific native version
+      # prebuilt_version: "1.4.0.6"  # Optional: pin specific native version
       # For source mode: build from local ExecuTorch checkout
       # build_mode: "source"
       # executorch_source: "/path/to/executorch"

--- a/packages/executorch_flutter/example/integration_test/vulkan_correctness_test.dart
+++ b/packages/executorch_flutter/example/integration_test/vulkan_correctness_test.dart
@@ -1,0 +1,469 @@
+// Vulkan output correctness against XNNPACK, on the same inputs.
+//
+// The benchmark test next door only times things: it would pass just as happily
+// on a backend that returned all-NaN. This one feeds byte-identical input to the
+// XNNPACK and Vulkan builds of the same model and compares what comes back.
+//
+// Context: PowerVR GPUs (Pixel 10 Pro) corrupt prepacked weights when several
+// prepack dispatches share one Vulkan command buffer, which shows up as NaN or
+// wildly wrong outputs while every timing test still passes.
+// See https://github.com/abdelaziz-mahdy/executorch_flutter/issues/26 and
+// https://github.com/pytorch/executorch/issues/17299.
+//
+// Usage: flutter test integration_test/vulkan_correctness_test.dart -d <device>
+
+// ignore_for_file: avoid_print
+
+@Timeout(Duration(minutes: 30))
+library;
+
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:executorch_flutter/executorch_flutter.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'package:executorch_flutter_example/services/model_index_service.dart';
+import 'package:executorch_flutter_example/services/model_download_service.dart';
+
+/// Deterministic input, so both backends see bit-identical bytes and any
+/// difference in the output is the backend's doing. A fixed ramp would leave
+/// large parts of the tensor identical and could hide per-texel corruption, so
+/// this is a cheap LCG instead.
+Float32List _deterministicInput(int count, {int seed = 0x2545F491}) {
+  final out = Float32List(count);
+  var state = seed;
+  for (var i = 0; i < count; i++) {
+    state = (state * 1103515245 + 12345) & 0x7FFFFFFF;
+    out[i] = (state % 10000) / 10000.0; // [0, 1)
+  }
+  return out;
+}
+
+Float32List _asFloat32(TensorData tensor) {
+  final bytes = tensor.data;
+  return bytes.buffer.asFloat32List(
+    bytes.offsetInBytes,
+    bytes.lengthInBytes ~/ 4,
+  );
+}
+
+class _Comparison {
+  _Comparison({
+    required this.nanCount,
+    required this.infCount,
+    required this.maxAbsDiff,
+    required this.meanAbsDiff,
+    required this.cosine,
+    required this.refArgmax,
+    required this.testArgmax,
+    required this.refAbsMax,
+    required this.worstRefValue,
+    required this.worstTestValue,
+    required this.refValueAtRefArgmax,
+    required this.refValueAtTestArgmax,
+    required this.length,
+  });
+
+  final int nanCount;
+  final int infCount;
+  final double maxAbsDiff;
+  final double meanAbsDiff;
+  final double cosine;
+  final int refArgmax;
+  final int testArgmax;
+
+  /// Largest magnitude in the reference tensor — the scale `maxAbsDiff` has to
+  /// be read against. A diff of 13.6 is corruption in a tensor that peaks at 20
+  /// and rounding noise in one that peaks at 5000.
+  final double refAbsMax;
+  final double worstRefValue;
+  final double worstTestValue;
+  final int length;
+
+  /// Reference values at the two peak positions.
+  ///
+  /// Index equality is the wrong test on YOLO's raw `[1, 84, 8400]` output: its
+  /// global maximum is a box coordinate near the image size, and many of the
+  /// 8400 anchors carry near-identical maxima, so FP16 noise reorders a tie and
+  /// moves the index while the tensor is unchanged. What must hold is that the
+  /// peak Vulkan picked is *also* a peak in the reference.
+  final double refValueAtRefArgmax;
+  final double refValueAtTestArgmax;
+
+  bool get argmaxMatches => refArgmax == testArgmax;
+
+  /// How far below the reference peak the Vulkan-chosen position sits, as a
+  /// fraction of the tensor scale. Zero when the indices agree, near zero for a
+  /// tie, large when Vulkan peaked somewhere the reference considers ordinary.
+  double get argmaxValueGap => refAbsMax > 0
+      ? (refValueAtRefArgmax - refValueAtTestArgmax).abs() / refAbsMax
+      : 0.0;
+
+  /// Worst elementwise difference as a fraction of the tensor's own scale.
+  double get relativeDiff => refAbsMax > 0 ? maxAbsDiff / refAbsMax : 0.0;
+
+  @override
+  String toString() =>
+      'len=$length NaN=$nanCount Inf=$infCount '
+      'maxDiff=${maxAbsDiff.toStringAsExponential(3)} '
+      '(${worstRefValue.toStringAsExponential(3)} vs '
+      '${worstTestValue.toStringAsExponential(3)}, '
+      'scale=${refAbsMax.toStringAsExponential(3)}, '
+      'rel=${relativeDiff.toStringAsExponential(3)}) '
+      'meanDiff=${meanAbsDiff.toStringAsExponential(3)} '
+      'cosine=${cosine.toStringAsFixed(6)} '
+      'argmax=$testArgmax (ref $refArgmax, '
+      'refVal ${refValueAtTestArgmax.toStringAsExponential(3)} vs peak '
+      '${refValueAtRefArgmax.toStringAsExponential(3)}, '
+      'gap=${argmaxValueGap.toStringAsExponential(3)})';
+}
+
+_Comparison _compare(Float32List reference, Float32List test) {
+  final n = math.min(reference.length, test.length);
+
+  var nanCount = 0;
+  var infCount = 0;
+  var maxAbsDiff = 0.0;
+  var sumAbsDiff = 0.0;
+  var dot = 0.0;
+  var refNorm = 0.0;
+  var testNorm = 0.0;
+  var refArgmax = 0;
+  var testArgmax = 0;
+  var refAbsMax = 0.0;
+  var worstRefValue = 0.0;
+  var worstTestValue = 0.0;
+
+  for (var i = 0; i < n; i++) {
+    final r = reference[i];
+    final t = test[i];
+
+    final refAbs = r.abs();
+    if (refAbs > refAbsMax) refAbsMax = refAbs;
+
+    if (t.isNaN) {
+      nanCount++;
+      continue; // NaN poisons every other statistic
+    }
+    if (t.isInfinite) {
+      infCount++;
+      continue;
+    }
+
+    final diff = (r - t).abs();
+    if (diff > maxAbsDiff) {
+      maxAbsDiff = diff;
+      worstRefValue = r;
+      worstTestValue = t;
+    }
+    sumAbsDiff += diff;
+
+    dot += r * t;
+    refNorm += r * r;
+    testNorm += t * t;
+
+    if (r > reference[refArgmax]) refArgmax = i;
+    if (t > test[testArgmax] || test[testArgmax].isNaN) testArgmax = i;
+  }
+
+  final finite = n - nanCount - infCount;
+  final denom = math.sqrt(refNorm) * math.sqrt(testNorm);
+
+  return _Comparison(
+    nanCount: nanCount,
+    infCount: infCount,
+    maxAbsDiff: maxAbsDiff,
+    meanAbsDiff: finite > 0 ? sumAbsDiff / finite : double.nan,
+    cosine: denom > 0 ? dot / denom : double.nan,
+    refArgmax: refArgmax,
+    testArgmax: testArgmax,
+    refAbsMax: refAbsMax,
+    worstRefValue: worstRefValue,
+    worstTestValue: worstTestValue,
+    refValueAtRefArgmax: reference[refArgmax],
+    refValueAtTestArgmax: reference[testArgmax],
+    length: n,
+  );
+}
+
+/// Assert one Vulkan run against the XNNPACK reference, tensor by tensor.
+///
+/// Thresholds are set against measured behaviour on both sides:
+///
+///  - The Vulkan `.pte` files are FP16 (half the size of the XNNPACK ones), so
+///    an absolute tolerance on raw activations is meaningless — a diff of 13.6
+///    is rounding noise in a tensor that peaks near 640. Everything below is
+///    therefore scale-relative or scale-free.
+///  - The prepack corruption this guards against was never subtle: it produced
+///    NaN across whole tensors, or wrong argmax with diffs of 4.27 and 50.12
+///    (pytorch/executorch#17299). Cosine similarity and argmax agreement both
+///    collapse under it while staying pinned near 1.0 under FP16 rounding.
+void _assertOutputsMatch(
+  String label,
+  int load,
+  List<Float32List> reference,
+  List<Float32List> actual,
+) {
+  for (var i = 0; i < reference.length; i++) {
+    final cmp = _compare(reference[i], actual[i]);
+    print('  load $load output[$i]: $cmp');
+
+    expect(
+      cmp.nanCount + cmp.infCount,
+      0,
+      reason: '$label load $load output[$i]: Vulkan produced NaN/Inf values',
+    );
+    // Not index equality — see the doc on `argmaxValueGap`. The position Vulkan
+    // peaked at must also be a peak in the reference; a tie reordered by FP16
+    // rounding is fine, peaking somewhere the reference considers ordinary is
+    // not.
+    expect(
+      cmp.argmaxValueGap,
+      lessThan(0.02),
+      reason: '$label load $load output[$i]: Vulkan peaked at index '
+          '${cmp.testArgmax}, where the reference holds '
+          '${cmp.refValueAtTestArgmax} — far below its own peak '
+          '${cmp.refValueAtRefArgmax} at index ${cmp.refArgmax}',
+    );
+    expect(
+      cmp.cosine,
+      greaterThan(0.999),
+      reason: '$label load $load output[$i]: cosine similarity ${cmp.cosine} — '
+          'the tensors disagree in shape, not just precision',
+    );
+    expect(
+      cmp.relativeDiff,
+      lessThan(0.05),
+      reason: '$label load $load output[$i]: worst element differs by '
+          '${(cmp.relativeDiff * 100).toStringAsFixed(1)}% of the tensor scale '
+          '(${cmp.worstRefValue} vs ${cmp.worstTestValue})',
+    );
+  }
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Vulkan output correctness vs XNNPACK', () {
+    late ExecutorchManager manager;
+    final Map<String, String> modelPaths = {};
+
+    Future<String> downloadModel(ModelIndexEntry entry) async {
+      final info = await ModelDownloadService.instance.downloadModel(
+        modelName: entry.name,
+        remoteUrl: entry.remoteUrl,
+        expectedHash: entry.hash,
+      );
+
+      if (info.state != ModelDownloadState.downloaded) {
+        throw Exception('Failed to download ${entry.name}: ${info.errorMessage}');
+      }
+      if (info.localPath != null) return info.localPath!;
+      if (info.bytes != null) {
+        final directory = await getApplicationCacheDirectory();
+        final file = File('${directory.path}/${entry.name}');
+        await file.writeAsBytes(info.bytes!);
+        return file.path;
+      }
+      throw Exception('Download succeeded but no path or bytes available');
+    }
+
+    setUpAll(() async {
+      manager = ExecutorchManager.instance;
+      await manager.initialize();
+
+      print('');
+      print('========================================');
+      print('  Vulkan correctness vs XNNPACK');
+      print('========================================');
+      print('Vulkan available : ${BackendQuery.isAvailable(Backend.vulkan)}');
+      print('XNNPACK available: ${BackendQuery.isAvailable(Backend.xnnpack)}');
+      print('');
+
+      const wanted = [
+        'mobilenet_v3_small_xnnpack.pte',
+        'mobilenet_v3_small_vulkan.pte',
+        'yolo11n_xnnpack.pte',
+        'yolo11n_vulkan.pte',
+        'yolov8n_xnnpack.pte',
+        'yolov8n_vulkan.pte',
+        'yolov5n_xnnpack.pte',
+        'yolov5n_vulkan.pte',
+      ];
+
+      // `flutter test` reinstalls the app every run, wiping its storage, so all
+      // ~70 MB comes down the wire each time. Pushing the files in with adb
+      // does not help: writes into Android/data/<package>/ land in the shell's
+      // storage view and the app cannot see them.
+      //
+      // The device radio drops connections often enough to fail a run outright,
+      // so retry rather than let a flaky download decide whether a GPU
+      // correctness test gets to run at all.
+      final index = await ModelIndexService.fetchIndex(forceRefresh: true);
+
+      for (final name in wanted) {
+        final matches = index.models.where((m) => m.name == name);
+        if (matches.isEmpty) {
+          print('  UNAVAILABLE: $name is not listed in the model index');
+          continue;
+        }
+
+        const attempts = 4;
+        for (var attempt = 1; attempt <= attempts; attempt++) {
+          try {
+            modelPaths[name] = await downloadModel(matches.first);
+            break;
+          } catch (e) {
+            final last = attempt == attempts;
+            print('  ${last ? "UNAVAILABLE" : "retry"}: $name '
+                'attempt $attempt/$attempts failed: $e');
+            if (last) break;
+            // A dropped connection tends to take the next few DNS lookups with
+            // it, so back off rather than retrying straight into the failure.
+            await Future<void>.delayed(Duration(seconds: 3 * attempt));
+          }
+        }
+      }
+      print('Models ready: ${modelPaths.length}/${wanted.length}');
+      print('');
+    });
+
+    tearDownAll(() async {
+      await manager.disposeAllModels();
+    });
+
+    /// Run one model on one input tensor and hand back its outputs as floats.
+    Future<List<Float32List>> runModel(
+      String modelName,
+      List<int> shape,
+      Float32List input,
+    ) async {
+      final path = modelPaths[modelName];
+      if (path == null) throw StateError('$modelName not downloaded');
+
+      final model = await ExecuTorchModel.load(path);
+      try {
+        final outputs = await model.forward([
+          TensorData(
+            shape: shape,
+            dataType: TensorType.float32,
+            data: input.buffer.asUint8List(),
+            name: 'input',
+          ),
+        ]);
+        // Copy out before dispose frees the native buffers.
+        return outputs.map((o) => Float32List.fromList(_asFloat32(o))).toList();
+      } finally {
+        await model.dispose();
+      }
+    }
+
+    Future<void> checkModel({
+      required String label,
+      required String xnnpackModel,
+      required String vulkanModel,
+      required List<int> shape,
+      // The corruption this guards against happened during prepack, at load
+      // time, and depended on dispatch ordering within a command buffer — so a
+      // single load is a thin sample. Each repeat is a fresh load of the model.
+      int loads = 4,
+    }) async {
+      // Never skip quietly. A comparison test that reports success because it
+      // had nothing to compare is worse than no test at all — it is exactly how
+      // a backend regression would slip through unnoticed.
+      if (!modelPaths.containsKey(xnnpackModel) ||
+          !modelPaths.containsKey(vulkanModel)) {
+        fail(
+          '$label: required models unavailable ($xnnpackModel / $vulkanModel). '
+          'See the setUpAll output above for the download error.',
+        );
+      }
+
+      final elementCount = shape.reduce((a, b) => a * b);
+      final input = _deterministicInput(elementCount);
+
+      print('--- $label ---');
+      final reference = await runModel(xnnpackModel, shape, input);
+
+      List<Float32List>? firstVulkanRun;
+      for (var load = 1; load <= loads; load++) {
+        final actual = await runModel(vulkanModel, shape, input);
+        expect(
+          actual.length,
+          reference.length,
+          reason: '$label: backends returned different output counts',
+        );
+
+        // Same weights, same input, same device: two loads must agree exactly.
+        // Any drift here is intermittent prepack corruption, which an
+        // against-reference check alone can miss when both loads are wrong the
+        // same way.
+        if (firstVulkanRun == null) {
+          firstVulkanRun = actual;
+        } else {
+          var crossRunDiff = 0.0;
+          for (var i = 0; i < actual.length; i++) {
+            for (var j = 0; j < actual[i].length; j++) {
+              final d = (firstVulkanRun[i][j] - actual[i][j]).abs();
+              if (d > crossRunDiff) crossRunDiff = d;
+            }
+          }
+          print('  load $load vs load 1: maxDiff='
+              '${crossRunDiff.toStringAsExponential(3)}');
+          expect(
+            crossRunDiff,
+            0.0,
+            reason:
+                '$label load $load: Vulkan output differs between loads of the '
+                'same model — prepack is not deterministic',
+          );
+        }
+
+        _assertOutputsMatch(label, load, reference, actual);
+      }
+      print('');
+    }
+
+    testWidgets('MobileNet V3 Small: Vulkan matches XNNPACK', (_) async {
+      await checkModel(
+        label: 'MobileNet V3 Small',
+        xnnpackModel: 'mobilenet_v3_small_xnnpack.pte',
+        vulkanModel: 'mobilenet_v3_small_vulkan.pte',
+        shape: [1, 3, 224, 224],
+      );
+    });
+
+    testWidgets('YOLO11n: Vulkan matches XNNPACK', (_) async {
+      // More prepack nodes than MobileNet, so a better shot at tripping the
+      // batched-dispatch corruption if it is still present.
+      await checkModel(
+        label: 'YOLO11n',
+        xnnpackModel: 'yolo11n_xnnpack.pte',
+        vulkanModel: 'yolo11n_vulkan.pte',
+        shape: [1, 3, 640, 640],
+      );
+    });
+
+    testWidgets('YOLOv8n: Vulkan matches XNNPACK', (_) async {
+      await checkModel(
+        label: 'YOLOv8n',
+        xnnpackModel: 'yolov8n_xnnpack.pte',
+        vulkanModel: 'yolov8n_vulkan.pte',
+        shape: [1, 3, 640, 640],
+      );
+    });
+
+    testWidgets('YOLOv5n: Vulkan matches XNNPACK', (_) async {
+      await checkModel(
+        label: 'YOLOv5n',
+        xnnpackModel: 'yolov5n_xnnpack.pte',
+        vulkanModel: 'yolov5n_vulkan.pte',
+        shape: [1, 3, 640, 640],
+      );
+    });
+  });
+}

--- a/packages/executorch_flutter/example/integration_test/vulkan_correctness_test.dart
+++ b/packages/executorch_flutter/example/integration_test/vulkan_correctness_test.dart
@@ -224,7 +224,8 @@ void _assertOutputsMatch(
     expect(
       cmp.argmaxValueGap,
       lessThan(0.02),
-      reason: '$label load $load output[$i]: Vulkan peaked at index '
+      reason:
+          '$label load $load output[$i]: Vulkan peaked at index '
           '${cmp.testArgmax}, where the reference holds '
           '${cmp.refValueAtTestArgmax} — far below its own peak '
           '${cmp.refValueAtRefArgmax} at index ${cmp.refArgmax}',
@@ -232,13 +233,15 @@ void _assertOutputsMatch(
     expect(
       cmp.cosine,
       greaterThan(0.999),
-      reason: '$label load $load output[$i]: cosine similarity ${cmp.cosine} — '
+      reason:
+          '$label load $load output[$i]: cosine similarity ${cmp.cosine} — '
           'the tensors disagree in shape, not just precision',
     );
     expect(
       cmp.relativeDiff,
       lessThan(0.05),
-      reason: '$label load $load output[$i]: worst element differs by '
+      reason:
+          '$label load $load output[$i]: worst element differs by '
           '${(cmp.relativeDiff * 100).toStringAsFixed(1)}% of the tensor scale '
           '(${cmp.worstRefValue} vs ${cmp.worstTestValue})',
     );
@@ -260,7 +263,9 @@ void main() {
       );
 
       if (info.state != ModelDownloadState.downloaded) {
-        throw Exception('Failed to download ${entry.name}: ${info.errorMessage}');
+        throw Exception(
+          'Failed to download ${entry.name}: ${info.errorMessage}',
+        );
       }
       if (info.localPath != null) return info.localPath!;
       if (info.bytes != null) {
@@ -319,8 +324,10 @@ void main() {
             break;
           } catch (e) {
             final last = attempt == attempts;
-            print('  ${last ? "UNAVAILABLE" : "retry"}: $name '
-                'attempt $attempt/$attempts failed: $e');
+            print(
+              '  ${last ? "UNAVAILABLE" : "retry"}: $name '
+              'attempt $attempt/$attempts failed: $e',
+            );
             if (last) break;
             // A dropped connection tends to take the next few DNS lookups with
             // it, so back off rather than retrying straight into the failure.
@@ -412,8 +419,10 @@ void main() {
               if (d > crossRunDiff) crossRunDiff = d;
             }
           }
-          print('  load $load vs load 1: maxDiff='
-              '${crossRunDiff.toStringAsExponential(3)}');
+          print(
+            '  load $load vs load 1: maxDiff='
+            '${crossRunDiff.toStringAsExponential(3)}',
+          );
           expect(
             crossRunDiff,
             0.0,

--- a/packages/executorch_flutter/example/integration_test/vulkan_prediction_test.dart
+++ b/packages/executorch_flutter/example/integration_test/vulkan_prediction_test.dart
@@ -1,0 +1,359 @@
+// Do the Vulkan builds make the *right* predictions on real images?
+//
+// vulkan_correctness_test.dart proves Vulkan and XNNPACK agree numerically, but
+// it feeds pseudo-random noise: it would pass just as happily if both backends
+// were confidently wrong, and its "argmax" on noise is not a prediction of
+// anything. This test runs actual photographs through the full app pipeline —
+// the same preprocessors and postprocessors the example app uses — and checks
+// the predictions mean what they should.
+//
+// Usage: flutter test integration_test/vulkan_prediction_test.dart -d <device>
+
+// ignore_for_file: avoid_print
+
+@Timeout(Duration(minutes: 30))
+library;
+
+import 'dart:io';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:executorch_flutter/executorch_flutter.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'package:executorch_flutter_example/processors/image_processor.dart';
+import 'package:executorch_flutter_example/processors/yolo_processor.dart';
+import 'package:executorch_flutter_example/processors/imagelib/imagelib_mobilenet_preprocessor.dart';
+import 'package:executorch_flutter_example/processors/imagelib/imagelib_yolo_preprocessor.dart';
+import 'package:executorch_flutter_example/processors/yolo_output_processor.dart';
+import 'package:executorch_flutter_example/services/model_index_service.dart';
+import 'package:executorch_flutter_example/services/model_download_service.dart';
+
+/// ImageNet indices for the classes we assert on.
+///
+/// MobileNet is free to disagree with itself about *which* cat, so a range is
+/// the honest assertion — what would signal breakage is "cat photo classified
+/// as an object".
+const _catClasses = {281, 282, 283, 284, 285}; // tabby .. Egyptian cat
+
+/// ImageNet dog breeds occupy one contiguous block, 151 (Chihuahua) through
+/// 268 (Mexican hairless). Asserting on a hand-picked subset instead just
+/// encodes which breeds happened to come to mind — dog.jpg classifies as 162
+/// (beagle), which a sparse list misses while the model is perfectly right.
+final _dogClasses = List<int>.generate(268 - 151 + 1, (i) => 151 + i).toSet();
+
+/// COCO class index for `person`, the top detection expected in person.jpg.
+const _cocoPerson = 0;
+
+List<double> _softmax(List<double> logits) {
+  final maxLogit = logits.reduce(math.max);
+  final exps = logits.map((l) => math.exp(l - maxLogit)).toList();
+  final sum = exps.reduce((a, b) => a + b);
+  return exps.map((e) => e / sum).toList();
+}
+
+Float32List _asFloat32(TensorData tensor) => tensor.data.buffer.asFloat32List(
+      tensor.data.offsetInBytes,
+      tensor.data.lengthInBytes ~/ 4,
+    );
+
+class _TopK {
+  _TopK(this.indices, this.probabilities);
+  final List<int> indices;
+  final List<double> probabilities;
+
+  int get top1 => indices.first;
+  double get top1Probability => probabilities.first;
+
+  String describe() {
+    final parts = <String>[];
+    for (var i = 0; i < math.min(3, indices.length); i++) {
+      parts.add('${indices[i]}@${(probabilities[i] * 100).toStringAsFixed(1)}%');
+    }
+    return parts.join(', ');
+  }
+}
+
+_TopK _topK(Float32List logits, int k) {
+  final probs = _softmax(logits.toList());
+  final order = List<int>.generate(probs.length, (i) => i)
+    ..sort((a, b) => probs[b].compareTo(probs[a]));
+  final top = order.take(k).toList();
+  return _TopK(top, top.map((i) => probs[i]).toList());
+}
+
+double _iou(BoundingBox a, BoundingBox b) {
+  final left = math.max(a.x, b.x);
+  final top = math.max(a.y, b.y);
+  final right = math.min(a.x + a.width, b.x + b.width);
+  final bottom = math.min(a.y + a.height, b.y + b.height);
+  if (right <= left || bottom <= top) return 0.0;
+  final overlap = (right - left) * (bottom - top);
+  return overlap / (a.width * a.height + b.width * b.height - overlap);
+}
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Vulkan predictions on real images', () {
+    late ExecutorchManager manager;
+    final Map<String, String> modelPaths = {};
+
+    Future<String> downloadModel(ModelIndexEntry entry) async {
+      final info = await ModelDownloadService.instance.downloadModel(
+        modelName: entry.name,
+        remoteUrl: entry.remoteUrl,
+        expectedHash: entry.hash,
+      );
+      if (info.state != ModelDownloadState.downloaded) {
+        throw Exception('Failed to download ${entry.name}: ${info.errorMessage}');
+      }
+      if (info.localPath != null) return info.localPath!;
+      if (info.bytes != null) {
+        final dir = await getApplicationCacheDirectory();
+        final file = File('${dir.path}/${entry.name}');
+        await file.writeAsBytes(info.bytes!);
+        return file.path;
+      }
+      throw Exception('Download succeeded but no path or bytes available');
+    }
+
+    setUpAll(() async {
+      manager = ExecutorchManager.instance;
+      await manager.initialize();
+
+      print('');
+      print('========================================');
+      print('  Vulkan predictions on real images');
+      print('========================================');
+      print('');
+
+      const wanted = [
+        'mobilenet_v3_small_xnnpack.pte',
+        'mobilenet_v3_small_vulkan.pte',
+        'yolo11n_xnnpack.pte',
+        'yolo11n_vulkan.pte',
+      ];
+
+      final index = await ModelIndexService.fetchIndex(forceRefresh: true);
+      for (final name in wanted) {
+        final matches = index.models.where((m) => m.name == name);
+        if (matches.isEmpty) {
+          print('  UNAVAILABLE: $name not in index');
+          continue;
+        }
+        const attempts = 4;
+        for (var attempt = 1; attempt <= attempts; attempt++) {
+          try {
+            modelPaths[name] = await downloadModel(matches.first);
+            break;
+          } catch (e) {
+            final last = attempt == attempts;
+            print('  ${last ? "UNAVAILABLE" : "retry"}: $name '
+                'attempt $attempt/$attempts: $e');
+            if (last) break;
+            await Future<void>.delayed(Duration(seconds: 3 * attempt));
+          }
+        }
+      }
+      print('Models ready: ${modelPaths.length}/${wanted.length}');
+      print('');
+    });
+
+    tearDownAll(() async {
+      await manager.disposeAllModels();
+    });
+
+    Future<List<TensorData>> runModel(
+      String modelName,
+      List<TensorData> inputs,
+    ) async {
+      final path = modelPaths[modelName];
+      if (path == null) fail('$modelName unavailable — see setUpAll output');
+
+      final model = await ExecuTorchModel.load(path);
+      try {
+        final outputs = await model.forward(inputs);
+        return outputs
+            .map((o) => TensorData(
+                  shape: o.shape,
+                  dataType: o.dataType,
+                  data: Uint8List.fromList(o.data),
+                  name: o.name,
+                ))
+            .toList();
+      } finally {
+        await model.dispose();
+      }
+    }
+
+    testWidgets('MobileNet classifies real photos on both backends',
+        (_) async {
+      final preprocessor = ImageLibMobileNetPreprocessor(
+        config: const ImagePreprocessConfig(),
+      );
+
+      for (final probe in [
+        ('cat.jpg', _catClasses, 'cat'),
+        ('dog.jpg', _dogClasses, 'dog'),
+      ]) {
+        final (asset, expectedClasses, label) = probe;
+        final bytes = (await rootBundle.load('assets/images/$asset'))
+            .buffer
+            .asUint8List();
+        final inputs = await preprocessor.preprocess(bytes);
+
+        final xnnpack = _topK(
+          _asFloat32((await runModel('mobilenet_v3_small_xnnpack.pte', inputs))
+              .first),
+          5,
+        );
+        final vulkan = _topK(
+          _asFloat32(
+              (await runModel('mobilenet_v3_small_vulkan.pte', inputs)).first),
+          5,
+        );
+
+        print('--- $asset ---');
+        print('  XNNPACK top-3: ${xnnpack.describe()}');
+        print('  Vulkan  top-3: ${vulkan.describe()}');
+
+        expect(
+          expectedClasses.contains(xnnpack.top1),
+          isTrue,
+          reason: 'XNNPACK reference is itself wrong on $asset — top-1 class '
+              '${xnnpack.top1} is not a $label. The Vulkan comparison below '
+              'would be meaningless.',
+        );
+        expect(
+          expectedClasses.contains(vulkan.top1),
+          isTrue,
+          reason: 'Vulkan classified $asset as class ${vulkan.top1}, not a '
+              '$label',
+        );
+        expect(
+          vulkan.top1,
+          xnnpack.top1,
+          reason: 'Backends disagree on $asset: Vulkan says ${vulkan.top1}, '
+              'XNNPACK says ${xnnpack.top1}',
+        );
+        // FP16 shifts confidence a little; a large gap would mean the class
+        // won for different reasons on the two backends.
+        expect(
+          (vulkan.top1Probability - xnnpack.top1Probability).abs(),
+          lessThan(0.05),
+          reason: 'Confidence differs sharply on $asset: Vulkan '
+              '${vulkan.top1Probability} vs XNNPACK ${xnnpack.top1Probability}',
+        );
+        print('  PASS: both backends say class ${vulkan.top1} ($label)');
+        print('');
+      }
+    });
+
+    testWidgets('YOLO11n detects real objects on both backends', (_) async {
+      final preprocessor = ImageLibYoloPreprocessor(
+        config: const YoloPreprocessConfig(),
+      );
+      // Real COCO names are not bundled here, and the assertions below are on
+      // class index and geometry, so positional placeholders suffice.
+      final labels = List<String>.generate(80, (i) => 'class_$i');
+      final postprocessor = YoloOutputProcessor(
+        classLabels: labels,
+        inputWidth: 640,
+        inputHeight: 640,
+        confidenceThreshold: 0.25,
+        iouThreshold: 0.45,
+      );
+
+      final bytes = (await rootBundle.load('assets/images/person.jpg'))
+          .buffer
+          .asUint8List();
+      final inputs = await preprocessor.preprocess(bytes);
+
+      final xnnpackResult = await postprocessor
+          .process(await runModel('yolo11n_xnnpack.pte', inputs));
+      final vulkanResult = await postprocessor
+          .process(await runModel('yolo11n_vulkan.pte', inputs));
+
+      final refDets = xnnpackResult.detectedObjects;
+      final vkDets = vulkanResult.detectedObjects;
+
+      print('--- person.jpg ---');
+      print('  XNNPACK: ${refDets.length} detections');
+      for (final d in refDets.take(3)) {
+        print('    class ${d.classIndex} @ '
+            '${(d.confidence * 100).toStringAsFixed(1)}% '
+            'box=(${d.boundingBox.x.toStringAsFixed(1)}, '
+            '${d.boundingBox.y.toStringAsFixed(1)}, '
+            '${d.boundingBox.width.toStringAsFixed(1)}, '
+            '${d.boundingBox.height.toStringAsFixed(1)})');
+      }
+      print('  Vulkan : ${vkDets.length} detections');
+      for (final d in vkDets.take(3)) {
+        print('    class ${d.classIndex} @ '
+            '${(d.confidence * 100).toStringAsFixed(1)}% '
+            'box=(${d.boundingBox.x.toStringAsFixed(1)}, '
+            '${d.boundingBox.y.toStringAsFixed(1)}, '
+            '${d.boundingBox.width.toStringAsFixed(1)}, '
+            '${d.boundingBox.height.toStringAsFixed(1)})');
+      }
+
+      expect(
+        refDets,
+        isNotEmpty,
+        reason: 'XNNPACK reference found nothing in person.jpg — the Vulkan '
+            'comparison below would be meaningless',
+      );
+      expect(
+        vkDets,
+        isNotEmpty,
+        reason: 'Vulkan found no objects in person.jpg while XNNPACK found '
+            '${refDets.length}',
+      );
+
+      final refTop = refDets.first;
+      final vkTop = vkDets.first;
+
+      expect(
+        refTop.classIndex,
+        _cocoPerson,
+        reason: 'XNNPACK top detection is class ${refTop.classIndex}, not '
+            'person — the reference itself is wrong',
+      );
+      expect(
+        vkTop.classIndex,
+        _cocoPerson,
+        reason: 'Vulkan top detection is class ${vkTop.classIndex}, not person',
+      );
+
+      final overlap = _iou(refTop.boundingBox, vkTop.boundingBox);
+      print('  top-detection IoU: ${overlap.toStringAsFixed(4)}');
+      expect(
+        overlap,
+        greaterThan(0.9),
+        reason: 'Top boxes barely overlap (IoU $overlap) — the backends are '
+            'localising the same object differently',
+      );
+      expect(
+        (vkTop.confidence - refTop.confidence).abs(),
+        lessThan(0.05),
+        reason: 'Top-detection confidence differs sharply: Vulkan '
+            '${vkTop.confidence} vs XNNPACK ${refTop.confidence}',
+      );
+
+      // NMS is a thresholded process, so counts can legitimately differ by one
+      // near the cutoff — but not wildly.
+      expect(
+        (vkDets.length - refDets.length).abs(),
+        lessThanOrEqualTo(1),
+        reason: 'Detection counts diverge: Vulkan ${vkDets.length} vs XNNPACK '
+            '${refDets.length}',
+      );
+      print('  PASS: both backends detect person with IoU '
+          '${overlap.toStringAsFixed(4)}');
+    });
+  });
+}

--- a/packages/executorch_flutter/example/integration_test/vulkan_prediction_test.dart
+++ b/packages/executorch_flutter/example/integration_test/vulkan_prediction_test.dart
@@ -56,9 +56,9 @@ List<double> _softmax(List<double> logits) {
 }
 
 Float32List _asFloat32(TensorData tensor) => tensor.data.buffer.asFloat32List(
-      tensor.data.offsetInBytes,
-      tensor.data.lengthInBytes ~/ 4,
-    );
+  tensor.data.offsetInBytes,
+  tensor.data.lengthInBytes ~/ 4,
+);
 
 class _TopK {
   _TopK(this.indices, this.probabilities);
@@ -71,7 +71,9 @@ class _TopK {
   String describe() {
     final parts = <String>[];
     for (var i = 0; i < math.min(3, indices.length); i++) {
-      parts.add('${indices[i]}@${(probabilities[i] * 100).toStringAsFixed(1)}%');
+      parts.add(
+        '${indices[i]}@${(probabilities[i] * 100).toStringAsFixed(1)}%',
+      );
     }
     return parts.join(', ');
   }
@@ -109,7 +111,9 @@ void main() {
         expectedHash: entry.hash,
       );
       if (info.state != ModelDownloadState.downloaded) {
-        throw Exception('Failed to download ${entry.name}: ${info.errorMessage}');
+        throw Exception(
+          'Failed to download ${entry.name}: ${info.errorMessage}',
+        );
       }
       if (info.localPath != null) return info.localPath!;
       if (info.bytes != null) {
@@ -152,8 +156,10 @@ void main() {
             break;
           } catch (e) {
             final last = attempt == attempts;
-            print('  ${last ? "UNAVAILABLE" : "retry"}: $name '
-                'attempt $attempt/$attempts: $e');
+            print(
+              '  ${last ? "UNAVAILABLE" : "retry"}: $name '
+              'attempt $attempt/$attempts: $e',
+            );
             if (last) break;
             await Future<void>.delayed(Duration(seconds: 3 * attempt));
           }
@@ -178,20 +184,21 @@ void main() {
       try {
         final outputs = await model.forward(inputs);
         return outputs
-            .map((o) => TensorData(
-                  shape: o.shape,
-                  dataType: o.dataType,
-                  data: Uint8List.fromList(o.data),
-                  name: o.name,
-                ))
+            .map(
+              (o) => TensorData(
+                shape: o.shape,
+                dataType: o.dataType,
+                data: Uint8List.fromList(o.data),
+                name: o.name,
+              ),
+            )
             .toList();
       } finally {
         await model.dispose();
       }
     }
 
-    testWidgets('MobileNet classifies real photos on both backends',
-        (_) async {
+    testWidgets('MobileNet classifies real photos on both backends', (_) async {
       final preprocessor = ImageLibMobileNetPreprocessor(
         config: const ImagePreprocessConfig(),
       );
@@ -201,19 +208,21 @@ void main() {
         ('dog.jpg', _dogClasses, 'dog'),
       ]) {
         final (asset, expectedClasses, label) = probe;
-        final bytes = (await rootBundle.load('assets/images/$asset'))
-            .buffer
-            .asUint8List();
+        final bytes = (await rootBundle.load(
+          'assets/images/$asset',
+        )).buffer.asUint8List();
         final inputs = await preprocessor.preprocess(bytes);
 
         final xnnpack = _topK(
-          _asFloat32((await runModel('mobilenet_v3_small_xnnpack.pte', inputs))
-              .first),
+          _asFloat32(
+            (await runModel('mobilenet_v3_small_xnnpack.pte', inputs)).first,
+          ),
           5,
         );
         final vulkan = _topK(
           _asFloat32(
-              (await runModel('mobilenet_v3_small_vulkan.pte', inputs)).first),
+            (await runModel('mobilenet_v3_small_vulkan.pte', inputs)).first,
+          ),
           5,
         );
 
@@ -224,20 +233,23 @@ void main() {
         expect(
           expectedClasses.contains(xnnpack.top1),
           isTrue,
-          reason: 'XNNPACK reference is itself wrong on $asset — top-1 class '
+          reason:
+              'XNNPACK reference is itself wrong on $asset — top-1 class '
               '${xnnpack.top1} is not a $label. The Vulkan comparison below '
               'would be meaningless.',
         );
         expect(
           expectedClasses.contains(vulkan.top1),
           isTrue,
-          reason: 'Vulkan classified $asset as class ${vulkan.top1}, not a '
+          reason:
+              'Vulkan classified $asset as class ${vulkan.top1}, not a '
               '$label',
         );
         expect(
           vulkan.top1,
           xnnpack.top1,
-          reason: 'Backends disagree on $asset: Vulkan says ${vulkan.top1}, '
+          reason:
+              'Backends disagree on $asset: Vulkan says ${vulkan.top1}, '
               'XNNPACK says ${xnnpack.top1}',
         );
         // FP16 shifts confidence a little; a large gap would mean the class
@@ -245,7 +257,8 @@ void main() {
         expect(
           (vulkan.top1Probability - xnnpack.top1Probability).abs(),
           lessThan(0.05),
-          reason: 'Confidence differs sharply on $asset: Vulkan '
+          reason:
+              'Confidence differs sharply on $asset: Vulkan '
               '${vulkan.top1Probability} vs XNNPACK ${xnnpack.top1Probability}',
         );
         print('  PASS: both backends say class ${vulkan.top1} ($label)');
@@ -268,15 +281,17 @@ void main() {
         iouThreshold: 0.45,
       );
 
-      final bytes = (await rootBundle.load('assets/images/person.jpg'))
-          .buffer
-          .asUint8List();
+      final bytes = (await rootBundle.load(
+        'assets/images/person.jpg',
+      )).buffer.asUint8List();
       final inputs = await preprocessor.preprocess(bytes);
 
-      final xnnpackResult = await postprocessor
-          .process(await runModel('yolo11n_xnnpack.pte', inputs));
-      final vulkanResult = await postprocessor
-          .process(await runModel('yolo11n_vulkan.pte', inputs));
+      final xnnpackResult = await postprocessor.process(
+        await runModel('yolo11n_xnnpack.pte', inputs),
+      );
+      final vulkanResult = await postprocessor.process(
+        await runModel('yolo11n_vulkan.pte', inputs),
+      );
 
       final refDets = xnnpackResult.detectedObjects;
       final vkDets = vulkanResult.detectedObjects;
@@ -284,33 +299,39 @@ void main() {
       print('--- person.jpg ---');
       print('  XNNPACK: ${refDets.length} detections');
       for (final d in refDets.take(3)) {
-        print('    class ${d.classIndex} @ '
-            '${(d.confidence * 100).toStringAsFixed(1)}% '
-            'box=(${d.boundingBox.x.toStringAsFixed(1)}, '
-            '${d.boundingBox.y.toStringAsFixed(1)}, '
-            '${d.boundingBox.width.toStringAsFixed(1)}, '
-            '${d.boundingBox.height.toStringAsFixed(1)})');
+        print(
+          '    class ${d.classIndex} @ '
+          '${(d.confidence * 100).toStringAsFixed(1)}% '
+          'box=(${d.boundingBox.x.toStringAsFixed(1)}, '
+          '${d.boundingBox.y.toStringAsFixed(1)}, '
+          '${d.boundingBox.width.toStringAsFixed(1)}, '
+          '${d.boundingBox.height.toStringAsFixed(1)})',
+        );
       }
       print('  Vulkan : ${vkDets.length} detections');
       for (final d in vkDets.take(3)) {
-        print('    class ${d.classIndex} @ '
-            '${(d.confidence * 100).toStringAsFixed(1)}% '
-            'box=(${d.boundingBox.x.toStringAsFixed(1)}, '
-            '${d.boundingBox.y.toStringAsFixed(1)}, '
-            '${d.boundingBox.width.toStringAsFixed(1)}, '
-            '${d.boundingBox.height.toStringAsFixed(1)})');
+        print(
+          '    class ${d.classIndex} @ '
+          '${(d.confidence * 100).toStringAsFixed(1)}% '
+          'box=(${d.boundingBox.x.toStringAsFixed(1)}, '
+          '${d.boundingBox.y.toStringAsFixed(1)}, '
+          '${d.boundingBox.width.toStringAsFixed(1)}, '
+          '${d.boundingBox.height.toStringAsFixed(1)})',
+        );
       }
 
       expect(
         refDets,
         isNotEmpty,
-        reason: 'XNNPACK reference found nothing in person.jpg — the Vulkan '
+        reason:
+            'XNNPACK reference found nothing in person.jpg — the Vulkan '
             'comparison below would be meaningless',
       );
       expect(
         vkDets,
         isNotEmpty,
-        reason: 'Vulkan found no objects in person.jpg while XNNPACK found '
+        reason:
+            'Vulkan found no objects in person.jpg while XNNPACK found '
             '${refDets.length}',
       );
 
@@ -320,7 +341,8 @@ void main() {
       expect(
         refTop.classIndex,
         _cocoPerson,
-        reason: 'XNNPACK top detection is class ${refTop.classIndex}, not '
+        reason:
+            'XNNPACK top detection is class ${refTop.classIndex}, not '
             'person — the reference itself is wrong',
       );
       expect(
@@ -334,13 +356,15 @@ void main() {
       expect(
         overlap,
         greaterThan(0.9),
-        reason: 'Top boxes barely overlap (IoU $overlap) — the backends are '
+        reason:
+            'Top boxes barely overlap (IoU $overlap) — the backends are '
             'localising the same object differently',
       );
       expect(
         (vkTop.confidence - refTop.confidence).abs(),
         lessThan(0.05),
-        reason: 'Top-detection confidence differs sharply: Vulkan '
+        reason:
+            'Top-detection confidence differs sharply: Vulkan '
             '${vkTop.confidence} vs XNNPACK ${refTop.confidence}',
       );
 
@@ -349,11 +373,14 @@ void main() {
       expect(
         (vkDets.length - refDets.length).abs(),
         lessThanOrEqualTo(1),
-        reason: 'Detection counts diverge: Vulkan ${vkDets.length} vs XNNPACK '
+        reason:
+            'Detection counts diverge: Vulkan ${vkDets.length} vs XNNPACK '
             '${refDets.length}',
       );
-      print('  PASS: both backends detect person with IoU '
-          '${overlap.toStringAsFixed(4)}');
+      print(
+        '  PASS: both backends detect person with IoU '
+        '${overlap.toStringAsFixed(4)}',
+      );
     });
   });
 }

--- a/packages/executorch_flutter/example/integration_test/vulkan_vs_xnnpack_benchmark_test.dart
+++ b/packages/executorch_flutter/example/integration_test/vulkan_vs_xnnpack_benchmark_test.dart
@@ -34,7 +34,9 @@ void main() {
       );
 
       if (info.state != ModelDownloadState.downloaded) {
-        throw Exception('Failed to download ${entry.name}: ${info.errorMessage}');
+        throw Exception(
+          'Failed to download ${entry.name}: ${info.errorMessage}',
+        );
       }
 
       if (info.localPath != null) return info.localPath!;
@@ -191,7 +193,9 @@ void main() {
       if (xnnpackTimes.isNotEmpty && vulkanTimes.isNotEmpty) {
         final xAvg = xnnpackTimes.reduce((a, b) => a + b) / xnnpackTimes.length;
         final vAvg = vulkanTimes.reduce((a, b) => a + b) / vulkanTimes.length;
-        print('  Ratio: Vulkan is ${(vAvg / xAvg).toStringAsFixed(1)}x XNNPACK load time');
+        print(
+          '  Ratio: Vulkan is ${(vAvg / xAvg).toStringAsFixed(1)}x XNNPACK load time',
+        );
       }
 
       print('');
@@ -212,7 +216,9 @@ void main() {
       if (xnnpackTimes.isNotEmpty && vulkanTimes.isNotEmpty) {
         final xAvg = xnnpackTimes.reduce((a, b) => a + b) / xnnpackTimes.length;
         final vAvg = vulkanTimes.reduce((a, b) => a + b) / vulkanTimes.length;
-        print('  Ratio: Vulkan is ${(vAvg / xAvg).toStringAsFixed(1)}x XNNPACK load time');
+        print(
+          '  Ratio: Vulkan is ${(vAvg / xAvg).toStringAsFixed(1)}x XNNPACK load time',
+        );
       }
 
       print('');
@@ -239,7 +245,9 @@ void main() {
       if (xnnpackTimes.isNotEmpty && vulkanTimes.isNotEmpty) {
         final xAvg = xnnpackTimes.reduce((a, b) => a + b) / xnnpackTimes.length;
         final vAvg = vulkanTimes.reduce((a, b) => a + b) / vulkanTimes.length;
-        print('  Ratio: Vulkan is ${(vAvg / xAvg).toStringAsFixed(1)}x XNNPACK load time');
+        print(
+          '  Ratio: Vulkan is ${(vAvg / xAvg).toStringAsFixed(1)}x XNNPACK load time',
+        );
       }
 
       print('');
@@ -251,18 +259,20 @@ void main() {
       print('');
       print('--- YOLO11n Inference Time (5 runs after warmup) ---');
 
-      final xnnpackTimes = await benchmarkInference(
-        'yolo11n_xnnpack.pte',
-        [1, 3, 640, 640],
-        5,
-      );
+      final xnnpackTimes = await benchmarkInference('yolo11n_xnnpack.pte', [
+        1,
+        3,
+        640,
+        640,
+      ], 5);
       printBenchmarkResult('XNNPACK', xnnpackTimes);
 
-      final vulkanTimes = await benchmarkInference(
-        'yolo11n_vulkan.pte',
-        [1, 3, 640, 640],
-        5,
-      );
+      final vulkanTimes = await benchmarkInference('yolo11n_vulkan.pte', [
+        1,
+        3,
+        640,
+        640,
+      ], 5);
       printBenchmarkResult('Vulkan ', vulkanTimes);
 
       if (xnnpackTimes.isNotEmpty && vulkanTimes.isNotEmpty) {
@@ -284,18 +294,20 @@ void main() {
       print('');
       print('--- YOLOv8n Inference Time (5 runs after warmup) ---');
 
-      final xnnpackTimes = await benchmarkInference(
-        'yolov8n_xnnpack.pte',
-        [1, 3, 640, 640],
-        5,
-      );
+      final xnnpackTimes = await benchmarkInference('yolov8n_xnnpack.pte', [
+        1,
+        3,
+        640,
+        640,
+      ], 5);
       printBenchmarkResult('XNNPACK', xnnpackTimes);
 
-      final vulkanTimes = await benchmarkInference(
-        'yolov8n_vulkan.pte',
-        [1, 3, 640, 640],
-        5,
-      );
+      final vulkanTimes = await benchmarkInference('yolov8n_vulkan.pte', [
+        1,
+        3,
+        640,
+        640,
+      ], 5);
       printBenchmarkResult('Vulkan ', vulkanTimes);
 
       if (xnnpackTimes.isNotEmpty && vulkanTimes.isNotEmpty) {
@@ -350,7 +362,9 @@ void main() {
       print('  Benchmark Complete');
       print('========================================');
       print('');
-      print('Available backends: ${BackendQuery.available.map((b) => b.name).join(", ")}');
+      print(
+        'Available backends: ${BackendQuery.available.map((b) => b.name).join(", ")}',
+      );
       print('Models tested: ${modelPaths.keys.join(", ")}');
       print('');
       print('NOTE: Vulkan load time includes shader compilation');

--- a/packages/executorch_flutter/example/integration_test/vulkan_vs_xnnpack_benchmark_test.dart
+++ b/packages/executorch_flutter/example/integration_test/vulkan_vs_xnnpack_benchmark_test.dart
@@ -1,0 +1,362 @@
+// ignore_for_file: avoid_print
+
+@Timeout(Duration(minutes: 30))
+library;
+
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:executorch_flutter/executorch_flutter.dart';
+import 'package:path_provider/path_provider.dart';
+
+import 'package:executorch_flutter_example/services/model_index_service.dart';
+import 'package:executorch_flutter_example/services/model_download_service.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Vulkan vs XNNPACK Benchmark', () {
+    late ExecutorchManager manager;
+    final Map<String, String> modelPaths = {};
+
+    Future<String> downloadModel(ModelIndexEntry entry) async {
+      print('  Downloading ${entry.name} (${entry.sizeMB} MB)...');
+      final downloadService = ModelDownloadService.instance;
+      final info = await downloadService.downloadModel(
+        modelName: entry.name,
+        remoteUrl: entry.remoteUrl,
+        expectedHash: entry.hash,
+        onProgress: (progress, received, total) {
+          if (progress == 1.0) {
+            print('  100% downloaded');
+          }
+        },
+      );
+
+      if (info.state != ModelDownloadState.downloaded) {
+        throw Exception('Failed to download ${entry.name}: ${info.errorMessage}');
+      }
+
+      if (info.localPath != null) return info.localPath!;
+
+      if (info.bytes != null) {
+        final directory = await getApplicationCacheDirectory();
+        final file = File('${directory.path}/${entry.name}');
+        await file.writeAsBytes(info.bytes!);
+        return file.path;
+      }
+
+      throw Exception('Download succeeded but no path or bytes available');
+    }
+
+    setUpAll(() async {
+      manager = ExecutorchManager.instance;
+      await manager.initialize();
+
+      print('');
+      print('========================================');
+      print('  Vulkan vs XNNPACK Benchmark');
+      print('========================================');
+      print('');
+
+      // Check backend availability
+      final vulkanAvailable = BackendQuery.isAvailable(Backend.vulkan);
+      final xnnpackAvailable = BackendQuery.isAvailable(Backend.xnnpack);
+      print('Backends: XNNPACK=$xnnpackAvailable, Vulkan=$vulkanAvailable');
+      print('');
+
+      // Fetch model index
+      print('Fetching model index...');
+      final index = await ModelIndexService.fetchIndex(forceRefresh: true);
+
+      // Models to benchmark
+      final modelsToDownload = [
+        'yolo11n_xnnpack.pte',
+        'yolo11n_vulkan.pte',
+        'yolov8n_xnnpack.pte',
+        'yolov8n_vulkan.pte',
+        'mobilenet_v3_small_xnnpack.pte',
+        'mobilenet_v3_small_vulkan.pte',
+      ];
+
+      for (final modelName in modelsToDownload) {
+        try {
+          final entry = index.models.firstWhere((m) => m.name == modelName);
+          modelPaths[modelName] = await downloadModel(entry);
+        } catch (e) {
+          print('  SKIP: $modelName not found in index');
+        }
+      }
+
+      print('');
+      print('Downloaded ${modelPaths.length} models');
+      print('');
+    });
+
+    tearDownAll(() async {
+      await manager.disposeAllModels();
+    });
+
+    /// Benchmark model loading time (3 runs, report all + average)
+    Future<List<double>> benchmarkLoad(String modelName, int runs) async {
+      final path = modelPaths[modelName];
+      if (path == null) {
+        print('  SKIP: $modelName not available');
+        return [];
+      }
+
+      final times = <double>[];
+      for (var i = 0; i < runs; i++) {
+        final sw = Stopwatch()..start();
+        final model = await ExecuTorchModel.load(path);
+        sw.stop();
+        times.add(sw.elapsedMilliseconds.toDouble());
+        await model.dispose();
+      }
+      return times;
+    }
+
+    /// Benchmark inference time (multiple runs, report all + average)
+    Future<List<double>> benchmarkInference(
+      String modelName,
+      List<int> inputShape,
+      int runs,
+    ) async {
+      final path = modelPaths[modelName];
+      if (path == null) {
+        print('  SKIP: $modelName not available');
+        return [];
+      }
+
+      final model = await ExecuTorchModel.load(path);
+
+      final size = inputShape.reduce((a, b) => a * b);
+      final inputData = List.filled(size, 0.5);
+      final inputTensor = manager.createTensorData(
+        shape: inputShape,
+        dataType: TensorType.float32,
+        data: inputData,
+      );
+
+      final times = <double>[];
+
+      // Warmup run
+      try {
+        await model.forward([inputTensor]);
+      } catch (e) {
+        print('  Warmup failed for $modelName: $e');
+        await model.dispose();
+        return [];
+      }
+
+      for (var i = 0; i < runs; i++) {
+        final sw = Stopwatch()..start();
+        await model.forward([inputTensor]);
+        sw.stop();
+        times.add(sw.elapsedMilliseconds.toDouble());
+      }
+
+      await model.dispose();
+      return times;
+    }
+
+    void printBenchmarkResult(String label, List<double> times) {
+      if (times.isEmpty) {
+        print('  $label: SKIPPED');
+        return;
+      }
+      final avg = times.reduce((a, b) => a + b) / times.length;
+      final min = times.reduce((a, b) => a < b ? a : b);
+      final max = times.reduce((a, b) => a > b ? a : b);
+      print(
+        '  $label: avg=${avg.toStringAsFixed(1)}ms '
+        'min=${min.toStringAsFixed(1)}ms '
+        'max=${max.toStringAsFixed(1)}ms '
+        'runs=$times',
+      );
+    }
+
+    testWidgets('YOLO11n: Load time Vulkan vs XNNPACK', (
+      WidgetTester tester,
+    ) async {
+      print('');
+      print('--- YOLO11n Load Time (3 runs) ---');
+
+      final xnnpackTimes = await benchmarkLoad('yolo11n_xnnpack.pte', 3);
+      printBenchmarkResult('XNNPACK', xnnpackTimes);
+
+      final vulkanTimes = await benchmarkLoad('yolo11n_vulkan.pte', 3);
+      printBenchmarkResult('Vulkan ', vulkanTimes);
+
+      if (xnnpackTimes.isNotEmpty && vulkanTimes.isNotEmpty) {
+        final xAvg = xnnpackTimes.reduce((a, b) => a + b) / xnnpackTimes.length;
+        final vAvg = vulkanTimes.reduce((a, b) => a + b) / vulkanTimes.length;
+        print('  Ratio: Vulkan is ${(vAvg / xAvg).toStringAsFixed(1)}x XNNPACK load time');
+      }
+
+      print('');
+    });
+
+    testWidgets('YOLOv8n: Load time Vulkan vs XNNPACK', (
+      WidgetTester tester,
+    ) async {
+      print('');
+      print('--- YOLOv8n Load Time (3 runs) ---');
+
+      final xnnpackTimes = await benchmarkLoad('yolov8n_xnnpack.pte', 3);
+      printBenchmarkResult('XNNPACK', xnnpackTimes);
+
+      final vulkanTimes = await benchmarkLoad('yolov8n_vulkan.pte', 3);
+      printBenchmarkResult('Vulkan ', vulkanTimes);
+
+      if (xnnpackTimes.isNotEmpty && vulkanTimes.isNotEmpty) {
+        final xAvg = xnnpackTimes.reduce((a, b) => a + b) / xnnpackTimes.length;
+        final vAvg = vulkanTimes.reduce((a, b) => a + b) / vulkanTimes.length;
+        print('  Ratio: Vulkan is ${(vAvg / xAvg).toStringAsFixed(1)}x XNNPACK load time');
+      }
+
+      print('');
+    });
+
+    testWidgets('MobileNet V3: Load time Vulkan vs XNNPACK', (
+      WidgetTester tester,
+    ) async {
+      print('');
+      print('--- MobileNet V3 Load Time (3 runs) ---');
+
+      final xnnpackTimes = await benchmarkLoad(
+        'mobilenet_v3_small_xnnpack.pte',
+        3,
+      );
+      printBenchmarkResult('XNNPACK', xnnpackTimes);
+
+      final vulkanTimes = await benchmarkLoad(
+        'mobilenet_v3_small_vulkan.pte',
+        3,
+      );
+      printBenchmarkResult('Vulkan ', vulkanTimes);
+
+      if (xnnpackTimes.isNotEmpty && vulkanTimes.isNotEmpty) {
+        final xAvg = xnnpackTimes.reduce((a, b) => a + b) / xnnpackTimes.length;
+        final vAvg = vulkanTimes.reduce((a, b) => a + b) / vulkanTimes.length;
+        print('  Ratio: Vulkan is ${(vAvg / xAvg).toStringAsFixed(1)}x XNNPACK load time');
+      }
+
+      print('');
+    });
+
+    testWidgets('YOLO11n: Inference time Vulkan vs XNNPACK', (
+      WidgetTester tester,
+    ) async {
+      print('');
+      print('--- YOLO11n Inference Time (5 runs after warmup) ---');
+
+      final xnnpackTimes = await benchmarkInference(
+        'yolo11n_xnnpack.pte',
+        [1, 3, 640, 640],
+        5,
+      );
+      printBenchmarkResult('XNNPACK', xnnpackTimes);
+
+      final vulkanTimes = await benchmarkInference(
+        'yolo11n_vulkan.pte',
+        [1, 3, 640, 640],
+        5,
+      );
+      printBenchmarkResult('Vulkan ', vulkanTimes);
+
+      if (xnnpackTimes.isNotEmpty && vulkanTimes.isNotEmpty) {
+        final xAvg = xnnpackTimes.reduce((a, b) => a + b) / xnnpackTimes.length;
+        final vAvg = vulkanTimes.reduce((a, b) => a + b) / vulkanTimes.length;
+        final ratio = vAvg / xAvg;
+        print(
+          '  Ratio: Vulkan is ${ratio.toStringAsFixed(1)}x XNNPACK inference time '
+          '(${ratio < 1 ? "faster" : "slower"})',
+        );
+      }
+
+      print('');
+    });
+
+    testWidgets('YOLOv8n: Inference time Vulkan vs XNNPACK', (
+      WidgetTester tester,
+    ) async {
+      print('');
+      print('--- YOLOv8n Inference Time (5 runs after warmup) ---');
+
+      final xnnpackTimes = await benchmarkInference(
+        'yolov8n_xnnpack.pte',
+        [1, 3, 640, 640],
+        5,
+      );
+      printBenchmarkResult('XNNPACK', xnnpackTimes);
+
+      final vulkanTimes = await benchmarkInference(
+        'yolov8n_vulkan.pte',
+        [1, 3, 640, 640],
+        5,
+      );
+      printBenchmarkResult('Vulkan ', vulkanTimes);
+
+      if (xnnpackTimes.isNotEmpty && vulkanTimes.isNotEmpty) {
+        final xAvg = xnnpackTimes.reduce((a, b) => a + b) / xnnpackTimes.length;
+        final vAvg = vulkanTimes.reduce((a, b) => a + b) / vulkanTimes.length;
+        final ratio = vAvg / xAvg;
+        print(
+          '  Ratio: Vulkan is ${ratio.toStringAsFixed(1)}x XNNPACK inference time '
+          '(${ratio < 1 ? "faster" : "slower"})',
+        );
+      }
+
+      print('');
+    });
+
+    testWidgets('MobileNet V3: Inference time Vulkan vs XNNPACK', (
+      WidgetTester tester,
+    ) async {
+      print('');
+      print('--- MobileNet V3 Inference Time (5 runs after warmup) ---');
+
+      final xnnpackTimes = await benchmarkInference(
+        'mobilenet_v3_small_xnnpack.pte',
+        [1, 3, 224, 224],
+        5,
+      );
+      printBenchmarkResult('XNNPACK', xnnpackTimes);
+
+      final vulkanTimes = await benchmarkInference(
+        'mobilenet_v3_small_vulkan.pte',
+        [1, 3, 224, 224],
+        5,
+      );
+      printBenchmarkResult('Vulkan ', vulkanTimes);
+
+      if (xnnpackTimes.isNotEmpty && vulkanTimes.isNotEmpty) {
+        final xAvg = xnnpackTimes.reduce((a, b) => a + b) / xnnpackTimes.length;
+        final vAvg = vulkanTimes.reduce((a, b) => a + b) / vulkanTimes.length;
+        final ratio = vAvg / xAvg;
+        print(
+          '  Ratio: Vulkan is ${ratio.toStringAsFixed(1)}x XNNPACK inference time '
+          '(${ratio < 1 ? "faster" : "slower"})',
+        );
+      }
+
+      print('');
+    });
+
+    testWidgets('Summary', (WidgetTester tester) async {
+      print('');
+      print('========================================');
+      print('  Benchmark Complete');
+      print('========================================');
+      print('');
+      print('Available backends: ${BackendQuery.available.map((b) => b.name).join(", ")}');
+      print('Models tested: ${modelPaths.keys.join(", ")}');
+      print('');
+      print('NOTE: Vulkan load time includes shader compilation');
+      print('and GPU resource allocation (prepacking weights to');
+      print('textures). This is a one-time cost per model load.');
+      print('');
+    });
+  });
+}

--- a/packages/executorch_flutter/pubspec.yaml
+++ b/packages/executorch_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: executorch_flutter
 description: >
   ExecuTorch on-device ML inference for Flutter using dart:ffi — vision models
   plus experimental streaming LLM. Android, iOS, macOS, Linux, Windows, Web.
-version: 0.7.0
+version: 0.7.1
 homepage: https://github.com/abdelaziz-mahdy/executorch_flutter
 repository: https://github.com/abdelaziz-mahdy/executorch_flutter
 
@@ -13,7 +13,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  executorch_dart: ^0.7.0
+  executorch_dart: ^0.7.1
   flutter:
     sdk: flutter
   flutter_web_plugins:


### PR DESCRIPTION
Picks up native [v1.4.0.6](https://github.com/abdelaziz-mahdy/executorch_native/releases/tag/v1.4.0.6) and adds the Vulkan tests written while closing #26.

## MoltenVK fix — closes #51

Every macOS Vulkan prebuilt failed at the consuming app's build:

```
install_name_tool: changing install names or rpaths can't be redone for:
  .dart_tool/lib/libMoltenVK.dylib (for architecture arm64)
  because larger updated load commands do not fit
```

A dylib's install name lives in a fixed-size load command whose spare room is reserved at link time. Native assets relocate bundled dylibs by rewriting that name to an absolute path (~100 chars), and the copied Homebrew `libMoltenVK.dylib` had **48 bytes** to grow into. Khronos's own build is worse at 16.

[executorch_native#23](https://github.com/abdelaziz-mahdy/executorch_native/pull/23) links the dylib from MoltenVK's static library with `-headerpad_max_install_names` instead of copying someone else's binary, and refuses to package a bundled library without headroom. Verified against the shipped `libexecutorch_ffi-macos-arm64-xnnpack-vulkan-release.tar.gz`:

```
headerpad     48 bytes  ->  12328 bytes
rewrite       the install_name_tool call from #51 now succeeds
runtime       dlopen OK, vkEnumerateInstanceExtensionProperties -> VK_SUCCESS
```

**Behavior change:** macOS Vulkan variants now require macOS 12+, the floor MoltenVK 1.4.x is compiled against. Not a regression — Homebrew's 1.4.1 had the same floor, it was never stated. Other variants keep macOS 11.

Thanks @dariyooo for a diagnosis that was correct down to the load command.

## Vulkan tests

Two integration tests, written while re-testing the PowerVR corruption in #26. The existing Vulkan test only measures elapsed time — it would pass on a backend returning NaN.

- **`vulkan_correctness_test.dart`** — identical input into the XNNPACK and Vulkan builds of the same model, compared per tensor for NaN, cosine similarity, and worst elementwise difference relative to the tensor's own scale. Repeats over several fresh loads and requires them bit-identical, since the corruption appeared during prepack and varied between loads.
- **`vulkan_prediction_test.dart`** — real photographs through the app's own preprocessors and postprocessors, asserting the classification and detection mean what they should rather than merely agreeing with each other.

Tolerances are scale-relative because the Vulkan models are FP16 against FP32 on CPU. Missing models fail rather than skip — a comparison reporting success with nothing to compare is how a regression slips through.

## Results on a Pixel 10 Pro (PowerVR), no workaround applied

16 fresh loads across 4 models, 76 tensor comparisons, zero NaN, every load bit-identical:

| model | tensors | NaN/Inf | min cosine | max rel. diff |
|---|---|---|---|---|
| MobileNet V3 Small | 4 | 0 | 0.999728 | 2.38% |
| YOLO11n | 24 | 0 | 0.999872 | 2.74% |
| YOLOv8n | 24 | 0 | 0.999899 | 2.12% |
| YOLOv5n | 24 | 0 | 0.999916 | 2.24% |

And on real images: cat.jpg → class 281 (tabby) at 37.1% vs 37.3%, dog.jpg → 162 (beagle) at 70.5% vs 69.4%, person.jpg → one person detected by both with IoU 0.9990.

That closed #26. Caveats are recorded there and upstream in pytorch/executorch#17299: both the phone's driver and ExecuTorch moved since February, so the fix is unattributed, and it's one device on one driver build.

## Checks

`flutter analyze` clean, `dart format` clean, 67 core tests and 5 wrapper tests pass.
