### PR TITLE
fix: gate Metal on arm64 so universal macOS builds resolve

### DIFF
--- a/packages/executorch_dart/CHANGELOG.md
+++ b/packages/executorch_dart/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.7.2
+
+### Fixed
+
+- macOS builds no longer fail with a 404 on a `macos-x86_64-...-metal`
+  prebuilt. Metal was enabled by default for all of macOS, but it builds
+  against PyTorch, which ships no macOS x86_64 wheels — so it is
+  Apple-Silicon only and no Intel artifact exists. Since a universal macOS
+  build compiles an x86_64 slice too, this broke Apple-Silicon developers who
+  never asked for Intel support. Metal is now gated on arm64, and each slice
+  gets the backends it can actually run.
+  Thanks @dariyooo ([#53](https://github.com/abdelaziz-mahdy/executorch_flutter/issues/53)).
+- A missing prebuilt now says which backend combination was requested and why
+  it does not exist, instead of reading like a network failure. The suggested
+  `build_mode: "source"` fallback also named `executorch_flutter:`, a key
+  rejected since 0.6.0, so following it produced a second error.
+
 ## 0.7.1
 
 ### Fixed

--- a/packages/executorch_dart/README.md
+++ b/packages/executorch_dart/README.md
@@ -53,7 +53,7 @@ automatically — there's nothing to compile by hand.
      packages/executorch_flutter/README.md) — bump this by hand on release. -->
 ```yaml
 dependencies:
-  executorch_dart: ^0.7.1
+  executorch_dart: ^0.7.2
 ```
 
 ## Quick Start

--- a/packages/executorch_dart/example/README.md
+++ b/packages/executorch_dart/example/README.md
@@ -8,7 +8,7 @@ Add the dependency:
 
 ```yaml
 dependencies:
-  executorch_dart: ^0.7.1
+  executorch_dart: ^0.7.2
 ```
 
 Load a model, run it, dispose it:

--- a/packages/executorch_dart/lib/src/build/run_build.dart
+++ b/packages/executorch_dart/lib/src/build/run_build.dart
@@ -268,6 +268,25 @@ Please verify the path to your local ExecuTorch checkout.
   final backendDefines = _getBackendDefines(input, targetOS);
   _logBackendConfiguration(logger, backendDefines);
 
+  // Metal is Apple-Silicon only. Dropping it on x86_64 is what keeps universal
+  // builds working at all, but a user who asked for it by name should be told
+  // it went away rather than having to spot it in the Disabled list.
+  final requestedBackends = input.userDefines['backends'] as List?;
+  final askedForMetal =
+      requestedBackends != null &&
+      (requestedBackends.contains('metal') ||
+          requestedBackends.contains('mps'));
+  if (targetOS == OS.macOS &&
+      askedForMetal &&
+      backendDefines['ET_BUILD_METAL'] != 'ON') {
+    logger.info(
+      '[executorch_dart] NOTE: Metal was requested but is not available for '
+      '${input.config.code.targetArchitecture} — it is an Apple-Silicon-only '
+      'backend, and no macOS x86_64 prebuilt includes it. Building without '
+      'Metal; XNNPACK and CoreML still apply.\n',
+    );
+  }
+
   // MLX requires a macOS 14.0+ deployment target. Flutter currently HARDCODES
   // the native-assets macOS target to 13 (flutter_tools
   // .../native_assets/macos/native_assets.dart: `targetMacOSVersion = 13`), so
@@ -470,8 +489,15 @@ Map<String, String?> _getBackendDefines(BuildInput input, OS targetOS) {
   // Platform support for each backend
   final isApplePlatform = targetOS == OS.iOS || targetOS == OS.macOS;
   final supportsCoreml = isApplePlatform;
-  // Metal (AOTI) backend is macOS-desktop only (replaces the deprecated MPS).
-  final supportsMetal = targetOS == OS.macOS;
+  // Metal (AOTI) backend is macOS-desktop, arm64 ONLY (replaces the deprecated
+  // MPS). The native build hardcodes Metal off for x86_64 — see X64_VARIANTS in
+  // scripts/build-macos.sh — so no macos-x86_64-*-metal prebuilt exists, and
+  // requesting one 404s on the hash file rather than failing with anything
+  // legible. Metal is on by default for macOS, so without this arch gate every
+  // Intel or universal build breaks at configure.
+  final supportsMetal =
+      targetOS == OS.macOS &&
+      input.config.code.targetArchitecture == Architecture.arm64;
   // MLX backend (Apple-Silicon GPU) is macOS-desktop, arm64 ONLY. The native
   // build only produces a macos-arm64-xnnpack-mlx-llm prebuilt; gating here on
   // arm64 too keeps the prebuilt-variant selection from requesting a

--- a/packages/executorch_dart/pubspec.yaml
+++ b/packages/executorch_dart/pubspec.yaml
@@ -2,7 +2,7 @@ name: executorch_dart
 description: >
   ExecuTorch on-device ML inference for pure Dart using dart:ffi — vision
   models plus experimental streaming LLM. Android, iOS, macOS, Linux, Windows.
-version: 0.7.1
+version: 0.7.2
 homepage: https://github.com/abdelaziz-mahdy/executorch_flutter
 repository: https://github.com/abdelaziz-mahdy/executorch_flutter
 

--- a/packages/executorch_flutter/CHANGELOG.md
+++ b/packages/executorch_flutter/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.7.2
+
+### Fixed
+
+- macOS builds no longer fail on a missing Metal prebuilt for the x86_64 slice
+  of a universal build. See the core package's changelog — Metal is
+  Apple-Silicon only and is now gated accordingly.
+  Thanks @dariyooo ([#53](https://github.com/abdelaziz-mahdy/executorch_flutter/issues/53)).
+
 ## 0.7.1
 
 ### Fixed

--- a/packages/executorch_flutter/example/android/gradle.properties
+++ b/packages/executorch_flutter/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/packages/executorch_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/executorch_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/packages/executorch_flutter/example/android/settings.gradle.kts
+++ b/packages/executorch_flutter/example/android/settings.gradle.kts
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.9.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("com.android.application") version "8.11.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include(":app")

--- a/packages/executorch_flutter/pubspec.yaml
+++ b/packages/executorch_flutter/pubspec.yaml
@@ -2,7 +2,7 @@ name: executorch_flutter
 description: >
   ExecuTorch on-device ML inference for Flutter using dart:ffi — vision models
   plus experimental streaming LLM. Android, iOS, macOS, Linux, Windows, Web.
-version: 0.7.1
+version: 0.7.2
 homepage: https://github.com/abdelaziz-mahdy/executorch_flutter
 repository: https://github.com/abdelaziz-mahdy/executorch_flutter
 
@@ -13,7 +13,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  executorch_dart: ^0.7.1
+  executorch_dart: ^0.7.2
   flutter:
     sdk: flutter
   flutter_web_plugins:


### PR DESCRIPTION
Fixes #53.

## What broke

Metal was enabled by default for all of macOS with no architecture gate:

```dart
final supportsMetal = targetOS == OS.macOS;                                  // no arch gate
final enableMetal = supportsMetal && (wantsMetal ?? (targetOS == OS.macOS)); // on by default
```

The build hook runs once per architecture. The x86_64 pass therefore asked for `libexecutorch_ffi-macos-x86_64-xnnpack-coreml-metal-release.tar.gz`, which is never published, and the whole build died at configure. Because macOS apps build both slices, this hit Apple-Silicon developers who never asked for Intel support — hence "universal macOS builds fail" rather than "Intel builds fail".

## Why there is no Intel Metal build, and never will be

Metal is AOTI-based and compiles against PyTorch's AOTInductor headers — `build-macos.sh` installs `torch==2.11.*` for exactly that. PyTorch stopped shipping macOS x86_64 wheels after 2.2.2:

| torch | macOS wheels |
|---|---|
| 2.2.2 | `macosx_10_9_x86_64`, `macosx_11_0_arm64` |
| 2.5.0 | `macosx_11_0_arm64` |
| 2.9.0 | `macosx_11_0_arm64` |
| 2.11.0 | `macosx_11_0_arm64` |

ExecuTorch's Metal backend has no arch guard of its own, so this is entirely upstream. The native build already encodes it — `X64_VARIANTS` has no Metal entry and the x86_64 calls pass metal `OFF`. Only the Dart side disagreed.

## The fix

```dart
final supportsMetal =
    targetOS == OS.macOS &&
    input.config.code.targetArchitecture == Architecture.arm64;
```

Mirrors the gate `supportsMlx` has carried for the same reason — its comment even predicts this failure. arm64 keeps `xnnpack-coreml-metal`; x86_64 resolves `xnnpack-coreml`, which exists. Metal ends up in the slice where it could actually run.

A note is printed if someone lists `metal` explicitly and the gate drops it, rather than leaving it to be spotted in the `Disabled:` line.

## Also: the error message (abdelaziz-mahdy/executorch_native#24)

It suggested configuring under `executorch_flutter:` — a key rejected since 0.6.0 — so following the advice produced a second error. It now names the requested combination, says it is not a network fault, and for `metal`/`mlx` on x86_64 explains the Apple-Silicon restriction directly.

## Verified

Reproduced and confirmed against the real release:

```
x86_64 + Metal   -> xnnpack-coreml-metal -> fatal, with the new hint
x86_64 no Metal  -> xnnpack-coreml       -> downloads, Configuring done
```

The second line is the state this PR produces. Worth noting a local `flutter build macos --release` on Apple Silicon builds arm64 only, so it does **not** reproduce the original failure — I had to force `-DCMAKE_OSX_ARCHITECTURES=x86_64` to see it.

`flutter analyze` clean, `dart format` clean over both full package trees, 67 core and 5 wrapper tests pass.
